### PR TITLE
Update flake config

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -7,10 +7,8 @@ if [ -n "$TRAVIS_BUILD_DIR" ]; then
 fi
 
 echo -e "\n  ..... Running flake8 on netconan to check style and docstrings"
-flake8 netconan --ignore=E501
-
-echo -e "\n  ..... Running flake8 on tests to check style and docstrings"
-flake8 tests --ignore=E501
+# Configuration for flake8 is taken from setup.cfg
+flake8
 
 echo -e "\n  ..... Running unit tests with pytest"
 python setup.py test

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,8 @@ testpaths=tests
 
 [bdist_wheel]
 universal=1
+
+[flake8]
+filename=*.py,
+ignore=E501,D401
+exclude=docs,__pychache__,.eggs,*.egg,build


### PR DESCRIPTION
*Purpose*:
Simplify flake8 config. It can (and should) be pulled from setup.cfg. This way any developers can run flake8 with no extra args and it will automatically have project-wide config.

*Implementation*:
Move configuration from travis build files to setup.cfg

*Notes*:
This PR also disables the D401 warning, which requires docstrings to have "imperative mood". I don't think that is a useful check, but happy to discuss.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/40)
<!-- Reviewable:end -->
