### PR TITLE
Preserve whitespace

### DIFF
--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -220,7 +220,7 @@ def generate_sensitive_word_regexes(sensitive_words):
 def replace_matching_item(compiled_regexes, input_line, pwd_lookup):
     """If line matches a regex, anonymize or remove the line."""
     # Collapse whitespace to simplify regexes
-    output_line = '{}'.format(' '.join(input_line.split()))
+    output_line = ' '.join(input_line.split())
 
     # Note: compiled_regexes is a list of lists; the inner list is a group of
     # related regexes
@@ -258,5 +258,4 @@ def replace_matching_item(compiled_regexes, input_line, pwd_lookup):
     # Restore leading and trailing whitespace for readability and context
     leading = input_line[:-len(input_line.lstrip())]
     trailing = input_line[len(input_line.rstrip()):]
-    output_line = '{}{}{}'.format(leading, output_line, trailing)
-    return output_line
+    return leading + output_line + trailing

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -207,7 +207,7 @@ def _extract_enclosing_text(val):
 def generate_default_sensitive_item_regexes():
     """Compile and return the default password and community line regexes."""
     combined_regexes = default_pwd_line_regexes + default_com_line_regexes + \
-                       default_catch_all_regexes
+        default_catch_all_regexes
     return [[(regex.compile(_ALLOWED_REGEX_PREFIX + regex_), num) for regex_, num in group]
             for group in combined_regexes]
 

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -207,7 +207,7 @@ def _extract_enclosing_text(val):
 def generate_default_sensitive_item_regexes():
     """Compile and return the default password and community line regexes."""
     combined_regexes = default_pwd_line_regexes + default_com_line_regexes + \
-        default_catch_all_regexes
+                       default_catch_all_regexes
     return [[(regex.compile(_ALLOWED_REGEX_PREFIX + regex_), num) for regex_, num in group]
             for group in combined_regexes]
 
@@ -219,8 +219,8 @@ def generate_sensitive_word_regexes(sensitive_words):
 
 def replace_matching_item(compiled_regexes, input_line, pwd_lookup):
     """If line matches a regex, anonymize or remove the line."""
-    # Collapse all whitespace to simplify regexes
-    output_line = '{}\n'.format(' '.join(input_line.split()))
+    # Collapse whitespace to simplify regexes
+    output_line = '{}'.format(' '.join(input_line.split()))
 
     # Note: compiled_regexes is a list of lists; the inner list is a group of
     # related regexes
@@ -254,4 +254,9 @@ def replace_matching_item(compiled_regexes, input_line, pwd_lookup):
         # If any matches existed in this regex group, stop processing more regexes
         if match_found:
             break
+
+    # Restore leading and trailing whitespace for readability and context
+    leading = input_line[:-len(input_line.lstrip())]
+    trailing = input_line[len(input_line.rstrip()):]
+    output_line = '{}{}{}'.format(leading, output_line, trailing)
     return output_line

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -396,9 +396,10 @@ def test_pwd_removal(regexes, config_line, sensitive_text):
 
 
 @pytest.mark.parametrize('whitespace', [
-    '  ',
+    ' ',
     '\t',
-    '\n'
+    '\n',
+    ' \t\n'
 ])
 def test_pwd_removal_preserve_leading_whitespace(regexes, whitespace):
     """Test leading whitespace is preserved in config lines."""

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -410,9 +410,10 @@ def test_pwd_removal_preserve_leading_whitespace(regexes, whitespace):
 
 
 @pytest.mark.parametrize('whitespace', [
-    '  ',
+    ' ',
     '\t',
-    '\n'
+    '\n',
+    ' \t\n'
 ])
 def test_pwd_removal_preserve_trailing_whitespace(regexes, whitespace):
     """Test trailing whitespace is preserved in config lines."""

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -388,11 +388,39 @@ def test__extract_enclosing_text(val, quote):
 
 
 @pytest.mark.parametrize('config_line,sensitive_text', sensitive_lines)
-def test_pwd_and_com_removal(regexes, config_line, sensitive_text):
+def test_pwd_removal(regexes, config_line, sensitive_text):
     """Test removal of passwords and communities from config lines."""
     config_line = config_line.format(sensitive_text)
     pwd_lookup = {}
     assert(sensitive_text not in replace_matching_item(regexes, config_line, pwd_lookup))
+
+
+@pytest.mark.parametrize('whitespace', [
+    '  ',
+    '\t',
+    '\n'
+])
+def test_pwd_removal_preserve_leading_whitespace(regexes, whitespace):
+    """Test leading whitespace is preserved in config lines."""
+    config_line = '{whitespace}{line}'.format(line='password secret',
+                                              whitespace=whitespace)
+    pwd_lookup = {}
+    processed_line = replace_matching_item(regexes, config_line, pwd_lookup)
+    assert(processed_line.startswith(whitespace))
+
+
+@pytest.mark.parametrize('whitespace', [
+    '  ',
+    '\t',
+    '\n'
+])
+def test_pwd_removal_preserve_trailing_whitespace(regexes, whitespace):
+    """Test trailing whitespace is preserved in config lines."""
+    config_line = '{line}{whitespace}'.format(line='password secret',
+                                              whitespace=whitespace)
+    pwd_lookup = {}
+    processed_line = replace_matching_item(regexes, config_line, pwd_lookup)
+    assert(processed_line.endswith(whitespace))
 
 
 @pytest.mark.parametrize('config_line,sensitive_text', sensitive_lines)
@@ -406,7 +434,7 @@ def test_pwd_and_com_removal(regexes, config_line, sensitive_text):
     'something { ',
     'something : '
 ])
-def test_pwd_and_com_removal_prepend(regexes, config_line, sensitive_text, prepend_text):
+def test_pwd_removal_prepend(regexes, config_line, sensitive_text, prepend_text):
     """Test that sensitive lines are still anonymized correctly if preceded by allowed text."""
     config_line = prepend_text + config_line.format(sensitive_text)
     pwd_lookup = {}
@@ -422,7 +450,7 @@ def test_pwd_and_com_removal_prepend(regexes, config_line, sensitive_text, prepe
     '\' something',
     '} something',
 ])
-def test_pwd_and_com_removal_append(regexes, config_line, sensitive_text, append_text):
+def test_pwd_removal_append(regexes, config_line, sensitive_text, append_text):
     """Test that sensitive lines are still anonymized correctly if followed by allowed text."""
     config_line = config_line.format(sensitive_text) + append_text
     pwd_lookup = {}
@@ -434,7 +462,7 @@ def test_pwd_and_com_removal_append(regexes, config_line, sensitive_text, append
     '      interface GigabitEthernet0/0',
     'ip address 1.2.3.4 255.255.255.0'
 ])
-def test_pwd_and_com_removal_insensitive_lines(regexes, config_line):
+def test_pwd_removal_insensitive_lines(regexes, config_line):
     """Make sure benign lines are not affected by sensitive_item_removal."""
     pwd_lookup = {}
     # Collapse all whitespace in original config_line and add newline since


### PR DESCRIPTION
Updated sensitive item removal to preserve leading and trailing whitespace (preserve more context and readability).

Fixes #65

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/66)
<!-- Reviewable:end -->
