### PR TITLE
Improve multi-password replacement behavior

### DIFF
--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -302,7 +302,7 @@ def replace_matching_item(compiled_regexes, input_line, pwd_lookup, reserved_wor
             sensitive_val = match.group(sensitive_item_num)
             if sensitive_val in reserved_words:
                 logging.debug('Skipping anonymization of reserved word: "%s"', sensitive_val)
-                break
+                continue
             anon_val = _anonymize_value(sensitive_val, pwd_lookup)
             output_line = compiled_re.sub(anon_val, output_line)
             logging.debug(

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -419,6 +419,17 @@ def test_pwd_removal(regexes, config_line, sensitive_text):
     assert(sensitive_text not in replace_matching_item(regexes, config_line, pwd_lookup))
 
 
+@pytest.mark.parametrize('config_line, sensitive_text', [
+('snmp-server user Someone Somegroup auth md5 ipaddress priv {0} something', 'RemoveMe'),
+('snmp-server user Someone Somegroup auth md5 {0} priv ipaddress something', 'RemoveMe')
+])
+def test_pwd_removal_and_preserve_reserved_word(regexes, config_line, sensitive_text):
+    """Test removal of passwords when reserved words must be skipped."""
+    config_line = config_line.format(sensitive_text)
+    pwd_lookup = {}
+    assert(sensitive_text not in replace_matching_item(regexes, config_line, pwd_lookup))
+
+
 @pytest.mark.parametrize('config_line', [
     'password ipaddress',
     'set community p2p',

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -420,8 +420,8 @@ def test_pwd_removal(regexes, config_line, sensitive_text):
 
 
 @pytest.mark.parametrize('config_line, sensitive_text', [
-('snmp-server user Someone Somegroup auth md5 ipaddress priv {0} something', 'RemoveMe'),
-('snmp-server user Someone Somegroup auth md5 {0} priv ipaddress something', 'RemoveMe')
+    ('snmp-server user Someone Somegroup auth md5 ipaddress priv {0} something', 'RemoveMe'),
+    ('snmp-server user Someone Somegroup auth md5 {0} priv ipaddress something', 'RemoveMe')
 ])
 def test_pwd_removal_and_preserve_reserved_word(regexes, config_line, sensitive_text):
     """Test removal of passwords when reserved words must be skipped."""


### PR DESCRIPTION
Fixed multiple-password-replacement behavior where passwords would be incorrectly left alone if a preceding password were a reserved word.

Fixes #74

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/75)
<!-- Reviewable:end -->
