### PR TITLE
Update snmp community regex

### DIFF
--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -34,7 +34,7 @@ extra_password_regexes = [
     [('key "\K([^"]+)', 1)],
     [('key-hash sha256 (\S+)', 1)],
     # Replace communities that do not look like well-known BGP communities (i.e. snmp communities)
-    [('set community \K((?!\d+|\d+\:\d+|gshut|internet|local-AS|no-advertise|no-export|none).+)', 1)],
+    [('set community \K((?!\(?(\d+|\d+\:\d+|gshut|internet|local-AS|no-advertise|no-export|none)\)?).+)', 1)],
     [('snmp-server mib community-map \K([^ :]+)', 1)],
     # Catch-all's matching what looks like hashed passwords
     [('\K("?\$9\$[^\s;"]+)', 1)],

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -511,11 +511,13 @@ def test_pwd_removal_append(regexes, config_line, sensitive_text, append_text):
     'ip address 1.2.3.4 255.255.255.0',
     'set community 12345',
     'set community 1234:5678',
+    'set community (1234:5678)',
     'set community gshut',
     'set community internet',
     'set community local-AS',
     'set community no-advertise',
     'set community no-export',
+    'set community (no-export)',
     'set community none',
 ])
 def test_pwd_removal_insensitive_lines(regexes, config_line):


### PR DESCRIPTION
Updated snmp community regex in `sensitive_item_removal` to permit additional syntax (well-known BGP and numeric communities in parenthesis, which is [permitted in Cisco XR](https://www.cisco.com/c/en/us/td/docs/routers/xr12000/software/xr12k_r4-0/routing/configuration/guide/rc40xr12k_chapter7.html)).

For example `set community (123:456)` and `set community (no-export)` are no longer anonymized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/79)
<!-- Reviewable:end -->
