### PR TITLE
SNMP community regex update

### DIFF
--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -37,7 +37,7 @@ _ALLOWED_REGEX_PREFIX = '(?:[^-_a-zA-Z\d] ?|^ ?)'
 _ANON_SENSITIVE_WORD_LEN = 6
 
 # Communities that are not SNMP communities and should be ignored/not anonymized
-# This include well-known BGP communities and numeric communities (can be in parenthesis, as allowed in Cisco XR)
+# This includes well-known BGP communities and numeric communities (can be in parenthesis, as allowed in Cisco XR)
 _IGNORED_COMMUNITIES = '(\(?(\d+|\d+\:\d+|gshut|internet|local-AS|no-advertise|no-export|none)\)?(?!\S))'
 
 # Text that is allowed to surround passwords, to be preserved

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -27,19 +27,6 @@ from .default_reserved_words import default_reserved_words
 from passlib.hash import cisco_type7, md5_crypt, sha512_crypt
 from six import b
 
-# These are extra regexes to find lines that seem like they might contain
-# sensitive info (these are not already caught by RANCID default regexes)
-extra_password_regexes = [
-    [('encrypted-password \K(\S+)', None)],
-    [('key "\K([^"]+)', 1)],
-    [('key-hash sha256 (\S+)', 1)],
-    # Replace communities that do not look like well-known BGP communities (i.e. snmp communities)
-    [('set community \K((?!\(?(\d+|\d+\:\d+|gshut|internet|local-AS|no-advertise|no-export|none)\)?).+)', 1)],
-    [('snmp-server mib community-map \K([^ :]+)', 1)],
-    # Catch-all's matching what looks like hashed passwords
-    [('\K("?\$9\$[^\s;"]+)', 1)],
-    [('\K("?\$1\$[^\s;"]+)', 1)],
-]
 
 # A regex matching any of the characters that are allowed to precede a password regex
 # (e.g. sensitive line is allowed to be in quotes or after a colon)
@@ -49,8 +36,26 @@ _ALLOWED_REGEX_PREFIX = '(?:[^-_a-zA-Z\d] ?|^ ?)'
 # Number of digits to extract from hash for sensitive keyword replacement
 _ANON_SENSITIVE_WORD_LEN = 6
 
+# Communities that are not SNMP communities and should be ignored/not anonymized
+# This include well-known BGP communities and numeric communities (can be in parenthesis, as allowed in Cisco XR)
+_IGNORED_COMMUNITIES = '(\(?(\d+|\d+\:\d+|gshut|internet|local-AS|no-advertise|no-export|none)\)?(?!\S))'
+
 # Text that is allowed to surround passwords, to be preserved
 _PASSWORD_ENCLOSING_TEXT = ['\'', '"', '\\\'', '\\"']
+
+# These are extra regexes to find lines that seem like they might contain
+# sensitive info (these are not already caught by RANCID default regexes)
+extra_password_regexes = [
+    [('encrypted-password \K(\S+)', None)],
+    [('key "\K([^"]+)', 1)],
+    [('key-hash sha256 (\S+)', 1)],
+    # Replace communities that do not look like well-known BGP communities (i.e. snmp communities)
+    [('set community \K((?!{ignore})\S+)'.format(ignore=_IGNORED_COMMUNITIES), 1)],
+    [('snmp-server mib community-map \K([^ :]+)', 1)],
+    # Catch-all's matching what looks like hashed passwords
+    [('\K("?\$9\$[^\s;"]+)', 1)],
+    [('\K("?\$1\$[^\s;"]+)', 1)],
+]
 
 
 class AsNumberAnonymizer(object):

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -125,7 +125,7 @@ arista_password_lines = [
 
 misc_password_lines = [
     ('my password is ', '$1$salt$abcdefghijklmnopqrs'),
-    ('set community {}', 'RemoveMe'),
+    ('set community {} trailing text', 'RemoveMe'),
     ('set community {}', '1234a'),
     ('set community {}', 'a1234')
 ]

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -125,7 +125,9 @@ arista_password_lines = [
 
 misc_password_lines = [
     ('my password is ', '$1$salt$abcdefghijklmnopqrs'),
-    ('set community {}', 'RemoveMe')
+    ('set community {}', 'RemoveMe'),
+    ('set community {}', '1234a'),
+    ('set community {}', 'a1234')
 ]
 
 sensitive_lines = (cisco_password_lines +
@@ -512,6 +514,8 @@ def test_pwd_removal_append(regexes, config_line, sensitive_text, append_text):
     'set community 12345',
     'set community 1234:5678',
     'set community (1234:5678)',
+    'set community 1234:5678 additive',
+    'set community (1234:5678) additive',
     'set community gshut',
     'set community internet',
     'set community local-AS',


### PR DESCRIPTION
Fixing two issues here:
* trailing words after communities are no longer grouped with the community/anonymized (e.g. `set community foo trailing text` will now be correctly anonymized to `set community netconanRemoved trailing text` instead of `set community netconanRemoved`)
* snmp communities that start with bgp communities (e.g. `gshutfoo` or `1234foo`) are now correctly identified as such and anonymized

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/81)
<!-- Reviewable:end -->
