### PR TITLE
Update snmp community regex

### DIFF
--- a/netconan/default_pwd_regexes.py
+++ b/netconan/default_pwd_regexes.py
@@ -102,7 +102,7 @@ default_pwd_line_regexes = [
 ]
 # Taken from RANCID community scrubbing regexes
 default_com_line_regexes = [
-    [('((snmp-server .*community)( [08])?) \K(\S+)', 4)],
+    [('((snmp-server (\S+ )*community)( [08])?) \K(\S+)', 5)],
     # TODO(https://github.com/intentionet/netconan/issues/5):
     # Confirm this catches all community possibilities for snmp-server
     [('(snmp-server host (\S+)( informs| traps| version '

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -98,7 +98,8 @@ cisco_snmp_community_lines = [
     ('snmp-server host 1.1.1.1 informs version 3 priv {} memory', 'RemoveMe'),
     ('snmp-server host 1.1.1.1 version 2c {}', 'RemoveMe'),
     ('snmp-server host 1.1.1.1 {} vrrp', 'RemoveMe'),
-    ('snmp-server mib community-map {}:100 context public1', 'RemoveMe')
+    ('snmp-server mib community-map {}:100 context public1', 'RemoveMe'),
+    ('snmp-server community {} RW 2', 'secretcommunity')
 ]
 
 # TODO(https://github.com/intentionet/netconan/issues/4):


### PR DESCRIPTION
Make snmp community regex match more specific syntax.

Previously Netconan would anonymize the first word after the last occurrence of `community`, e.g. consider the following line where `sercretcommunity` is the snmp community name to be anonymized:
* `snmp-server community secretcommunity RW 2`
after anonymization, it would become:
* `snmp-server community secretcommunity netconanRemoved 2`
in this PR after anonymization, now it becomes:
* `snmp-server community netconanRemoved RW 2`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/84)
<!-- Reviewable:end -->
