### PR TITLE
Handle additional snmp-community syntax

### DIFF
--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -52,6 +52,7 @@ extra_password_regexes = [
     # Replace communities that do not look like well-known BGP communities (i.e. snmp communities)
     [('set community \K((?!{ignore})\S+)'.format(ignore=_IGNORED_COMMUNITIES), 1)],
     [('snmp-server mib community-map \K([^ :]+)', 1)],
+    [('snmp-community \K(\S+)', 1)],
     # Catch-all's matching what looks like hashed passwords
     [('\K("?\$9\$[^\s;"]+)', 1)],
     [('\K("?\$1\$[^\s;"]+)', 1)],

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -100,7 +100,8 @@ cisco_snmp_community_lines = [
     ('snmp-server host 1.1.1.1 version 2c {}', 'RemoveMe'),
     ('snmp-server host 1.1.1.1 {} vrrp', 'RemoveMe'),
     ('snmp-server mib community-map {}:100 context public1', 'RemoveMe'),
-    ('snmp-server community {} RW 2', 'secretcommunity')
+    ('snmp-server community {} RW 2', 'secretcommunity'),
+    ('rf-switch snmp-community {}', 'RemoveMe')
 ]
 
 # TODO(https://github.com/intentionet/netconan/issues/4):


### PR DESCRIPTION
Add regex to handle alternate snmp-community syntax (`snmp-community` vs `snmp-server community`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/85)
<!-- Reviewable:end -->
