### PR TITLE
Update community regex to ignore more BGP communities

### DIFF
--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -42,7 +42,7 @@ _ANON_SENSITIVE_WORD_LEN = 6
 # Text followed by the word 'additive'
 _IGNORED_COMM_ADDITIVE = '\S+ additive'
 # Numeric, colon separated, and parameter ($) communities
-_IGNORED_COMM_COLON = '(peeras|\$\w+|\d+)(\:(peeras|\$\w+|\d+))?'
+_IGNORED_COMM_COLON = '(peeras|\$\w+|\d+)\:(peeras|\$\w+|\d+)'
 # List of communities enclosed in parenthesis, being permissive here for the
 # content inside the parenthesis for simplicity
 _IGNORED_COMM_LIST = '\([\S ]+\)'

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -28,17 +28,31 @@ from passlib.hash import cisco_type7, md5_crypt, sha512_crypt
 from six import b
 
 
-# A regex matching any of the characters that are allowed to precede a password regex
-# (e.g. sensitive line is allowed to be in quotes or after a colon)
+# A regex matching any of the characters that are allowed to precede a password
+# regex (e.g. sensitive line is allowed to be in quotes or after a colon)
 # This is an ignored group, so it does not muck with the password regex indicies
 _ALLOWED_REGEX_PREFIX = '(?:[^-_a-zA-Z\d] ?|^ ?)'
 
 # Number of digits to extract from hash for sensitive keyword replacement
 _ANON_SENSITIVE_WORD_LEN = 6
 
-# Communities that are not SNMP communities and should be ignored/not anonymized
-# This includes well-known BGP communities and numeric communities (can be in parenthesis, as allowed in Cisco XR)
-_IGNORED_COMMUNITIES = '(\(?(\d+|\d+\:\d+|gshut|internet|local-AS|no-advertise|no-export|none)\)?(?!\S))'
+# BGP communities should be ignored/not anonymized, and can be detected by the
+# following patterns, mostly extracted from examples at
+# https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r4-1/routing/command/reference/b_routing_cr41crs/b_routing_cr41crs_chapter_01000.html
+# Text followed by the word 'additive'
+_IGNORED_COMM_ADDITIVE = '\S+ additive'
+# Numeric, colon separated, and parameter ($) communities
+_IGNORED_COMM_COLON = '(peeras|\$\w+|\d+)(\:(peeras|\$\w+|\d+))?'
+# List of communities enclosed in parenthesis, being permissive here for the
+# content inside the parenthesis for simplicity
+_IGNORED_COMM_LIST = '\([\S ]+\)'
+# Well-known BPG communities
+_IGNORED_COMM_WELL_KNOWN = 'gshut|internet|local-AS|no-advertise|no-export|none'
+_IGNORED_COMMUNITIES = ('((\d+|{additive}|{colon}|{list}|{well_known})(?!\S))'
+                        .format(additive=_IGNORED_COMM_ADDITIVE,
+                                colon=_IGNORED_COMM_COLON,
+                                list=_IGNORED_COMM_LIST,
+                                well_known=_IGNORED_COMM_WELL_KNOWN))
 
 # Text that is allowed to surround passwords, to be preserved
 _PASSWORD_ENCLOSING_TEXT = ['\'', '"', '\\\'', '\\"']
@@ -49,8 +63,10 @@ extra_password_regexes = [
     [('encrypted-password \K(\S+)', None)],
     [('key "\K([^"]+)', 1)],
     [('key-hash sha256 (\S+)', 1)],
-    # Replace communities that do not look like well-known BGP communities (i.e. snmp communities)
-    [('set community \K((?!{ignore})\S+)'.format(ignore=_IGNORED_COMMUNITIES), 1)],
+    # Replace communities that do not look like well-known BGP communities
+    # i.e. snmp communities
+    [('set community \K((?!\(?{ignore}\)?)\S+)'
+      .format(ignore=_IGNORED_COMMUNITIES), 1)],
     [('snmp-server mib community-map \K([^ :]+)', 1)],
     # Catch-all's matching what looks like hashed passwords
     [('\K("?\$9\$[^\s;"]+)', 1)],

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -65,7 +65,7 @@ extra_password_regexes = [
     [('key-hash sha256 (\S+)', 1)],
     # Replace communities that do not look like well-known BGP communities
     # i.e. snmp communities
-    [('set community \K((?!\(?{ignore}\)?)\S+)'
+    [('set community \K((?!{ignore})\S+)'
       .format(ignore=_IGNORED_COMMUNITIES), 1)],
     [('snmp-server mib community-map \K([^ :]+)', 1)],
     # Catch-all's matching what looks like hashed passwords

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -525,6 +525,14 @@ def test_pwd_removal_append(regexes, config_line, sensitive_text, append_text):
     'set community no-export',
     'set community (no-export)',
     'set community none',
+    'set community (12345 123:456 $foo:$bar no-export)',
+    'set community (12345 123:456 $foo:$bar no-export) additive',
+    'set community $foo:123',
+    'set community $foo:$bar',
+    'set community 123:$bar',
+    'set community blah additive',
+    'set community no-export additive',
+    'set community peeras:24',
 ])
 def test_pwd_removal_insensitive_lines(regexes, config_line):
     """Make sure benign lines are not affected by sensitive_item_removal."""


### PR DESCRIPTION
### Context:
[Cisco UCS SNMP community syntax](https://www.cisco.com/c/en/us/td/docs/unified_computing/ucs/sw/cli/config/guide/2-0/b_UCSM_CLI_Configuration_Guide_2_0/b_UCSM_CLI_Configuration_Guide_2_0_chapter_0110.html) is very similar to [Cisco IOS BGP community syntax](https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r4-1/routing/command/reference/b_routing_cr41crs/b_routing_cr41crs_chapter_01000.html), where `set community blah` may be a sensitive line on one device but not on the other.  There are some clues to when the community name is a BGP community (and therefore is not sensitive), like when it is:
* a well-known community: `gshut`, `internet`, ...
* numeric: `1234`, `123:456`
* using a parameter or `peeras`: `$foo:123`, `$foo:$bar`, `peeras:24`
* a list of values in parenthesis: `($foo:123 123456 987:654)`, `(1234)`
* community name followed by the keyword 'additive': `blah additive`

`Netconan` already recognizes the first two cases and skips anonymization in those cases.

### In this PR:
Update `Netconan` snmp-community regex to recognize and skip the last three cases as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/86)
<!-- Reviewable:end -->
