### PR TITLE
Recursively process files and allow individual file inputs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ For *reversible operations* (specifically, IP address anonymization), Netconan c
 Running netconan
 ================
 
-Netconan processes all files not starting with ``.`` housed in the top level of the specified input directory and saves processed files in the specified output directory.
+Netconan processes the ``input`` file or recursively processes files in the ``input`` directory (skipping files starting with ``.``) and saves processed files at the specified ``output``.
 
 For more information about less commonly-used features, see the Netconan help (``-h``).  For more information on config file syntax, see `here <https://goo.gl/R74nmi>`_.
 
@@ -108,13 +108,13 @@ For more information about less commonly-used features, see the Netconan help (`
       -d DUMP_IP_MAP, --dump-ip-map DUMP_IP_MAP
                             Dump IP address anonymization map to specified file
       -i INPUT, --input INPUT
-                            Directory containing files to anonymize
+                            Input file or directory containing files to anonymize
       -l {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                             Determines what level of logs to display
       -n AS_NUMBERS, --as-numbers AS_NUMBERS
                             List of comma separated AS numbers to anonymize
       -o OUTPUT, --output OUTPUT
-                            Directory to place anonymized files
+                            Output file or directory where anonymized files are placed
       -p, --anonymize-passwords
                             Anonymize password and snmp community lines
       -r RESERVED_WORDS, --reserved-words RESERVED_WORDS

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 
 from __future__ import absolute_import
+import errno
 import logging
 import os
 import random
@@ -30,10 +31,10 @@ _DEFAULT_SALT_LENGTH = 16
 _CHAR_CHOICES = string.ascii_letters + string.digits
 
 
-def anonymize_files_in_dir(input_dir_path, output_dir_path, anon_pwd, anon_ip,
-                           salt=None, dumpfile=None, sensitive_words=None,
-                           undo_ip_anon=False, as_numbers=None, reserved_words=None):
-    """Anonymize each file in input directory and save to output directory."""
+def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
+                    salt=None, dumpfile=None, sensitive_words=None,
+                    undo_ip_anon=False, as_numbers=None, reserved_words=None):
+    """Anonymize each file in input and save to output."""
     anonymizer4 = None
     anonymizer6 = None
     anonymizer_as_num = None
@@ -59,19 +60,27 @@ def anonymize_files_in_dir(input_dir_path, output_dir_path, anon_pwd, anon_ip,
     if as_numbers is not None:
         anonymizer_as_num = AsNumberAnonymizer(as_numbers, salt)
 
-    for file_name in os.listdir(input_dir_path):
-        input_file = os.path.join(input_dir_path, file_name)
-        output_file = os.path.join(output_dir_path, file_name)
-        if os.path.isfile(input_file) and not file_name.startswith('.'):
-            logging.info("Anonymizing %s", file_name)
-            anonymize_file(input_file, output_file,
-                           compiled_regexes=compiled_regexes,
-                           pwd_lookup=pwd_lookup,
-                           anonymizer_sensitive_word=anonymizer_sensitive_word,
-                           anonymizer_as_num=anonymizer_as_num,
-                           undo_ip_anon=undo_ip_anon,
-                           anonymizer4=anonymizer4,
-                           anonymizer6=anonymizer6)
+    # Generate list of file tuples: (input file path, output file path)
+    if os.path.isfile(input_path):
+        file_list = [(input_path, output_path)]
+    else:
+        for root, dirs, files in os.walk(input_path):
+            rel_root = os.path.relpath(root, input_path)
+            file_list = [(
+                os.path.join(input_path, rel_root, f),
+                os.path.join(output_path, rel_root, f)
+            ) for f in files if not f.startswith('.')]
+
+    for in_path, out_path in file_list:
+        anonymize_file(in_path,
+                       out_path,
+                       compiled_regexes=compiled_regexes,
+                       pwd_lookup=pwd_lookup,
+                       anonymizer_sensitive_word=anonymizer_sensitive_word,
+                       anonymizer_as_num=anonymizer_as_num,
+                       undo_ip_anon=undo_ip_anon,
+                       anonymizer4=anonymizer4,
+                       anonymizer6=anonymizer6)
 
     if dumpfile is not None:
         with open(dumpfile, 'w') as f_out:
@@ -90,6 +99,18 @@ def anonymize_file(filename_in, filename_out, compiled_regexes=None,
     """
     logging.debug("File in  %s", filename_in)
     logging.debug("File out %s", filename_out)
+
+    # Make parent dirs for output file if they don't exist
+    dirname = os.path.dirname(filename_out)
+    if len(dirname) > 0:
+        try:
+            os.makedirs(dirname)
+        except OSError as e:
+            if e.errno == errno.EEXIST and os.path.isdir(dirname):
+                pass
+            else:
+                raise
+
     with open(filename_out, 'w') as f_out, open(filename_in, 'r') as f_in:
         for line in f_in:
             output_line = line

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -60,10 +60,20 @@ def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
     if as_numbers is not None:
         anonymizer_as_num = AsNumberAnonymizer(as_numbers, salt)
 
+    if not os.path.exists(input_path):
+        raise ValueError("Input does not exist")
+
     # Generate list of file tuples: (input file path, output file path)
+    file_list = []
     if os.path.isfile(input_path):
         file_list = [(input_path, output_path)]
     else:
+        if not os.listdir(input_path):
+            raise ValueError("Input directory is empty")
+        if os.path.isfile(output_path):
+            raise ValueError("Output path must be a directory if input path is "
+                             "a directory")
+
         for root, dirs, files in os.walk(input_path):
             rel_root = os.path.relpath(root, input_path)
             file_list = [(
@@ -102,6 +112,11 @@ def anonymize_file(filename_in, filename_out, compiled_regexes=None,
 
     # Make parent dirs for output file if they don't exist
     _mkdirs(filename_out)
+
+    if os.path.isdir(filename_out):
+        raise ValueError('Cannot write output file; '
+                         'output file is a directory ({})'
+                         .format(filename_out))
 
     with open(filename_out, 'w') as f_out, open(filename_in, 'r') as f_in:
         for line in f_in:

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -101,15 +101,7 @@ def anonymize_file(filename_in, filename_out, compiled_regexes=None,
     logging.debug("File out %s", filename_out)
 
     # Make parent dirs for output file if they don't exist
-    dirname = os.path.dirname(filename_out)
-    if len(dirname) > 0:
-        try:
-            os.makedirs(dirname)
-        except OSError as e:
-            if e.errno == errno.EEXIST and os.path.isdir(dirname):
-                pass
-            else:
-                raise
+    _mkdirs(filename_out)
 
     with open(filename_out, 'w') as f_out, open(filename_in, 'r') as f_in:
         for line in f_in:
@@ -133,3 +125,16 @@ def anonymize_file(filename_in, filename_out, compiled_regexes=None,
                 logging.debug("Input line:  %s", line.rstrip())
                 logging.debug("Output line: %s", output_line.rstrip())
             f_out.write(output_line)
+
+
+def _mkdirs(file_path):
+    """Make parent directories for the specified file if they don't exist."""
+    dir_path = os.path.dirname(file_path)
+    if len(dir_path) > 0:
+        try:
+            os.makedirs(dir_path)
+        except OSError as e:
+            if e.errno == errno.EEXIST and os.path.isdir(dir_path):
+                pass
+            else:
+                raise

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -64,7 +64,6 @@ def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
         raise ValueError("Input does not exist")
 
     # Generate list of file tuples: (input file path, output file path)
-    file_list = []
     if os.path.isfile(input_path):
         file_list = [(input_path, output_path)]
     else:

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -19,7 +19,7 @@ import logging
 import os
 import sys
 
-from .anonymize_files import anonymize_files_in_dir
+from .anonymize_files import anonymize_files
 
 
 def _parse_args(argv):
@@ -44,14 +44,14 @@ def _parse_args(argv):
     parser.add_argument('-d', '--dump-ip-map', default=None,
                         help='Dump IP address anonymization map to specified file')
     parser.add_argument('-i', '--input', required=True,
-                        help='Directory containing files to anonymize')
+                        help='Input file or directory containing files to anonymize')
     parser.add_argument('-l', '--log-level', default='INFO',
                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                         help='Determines what level of logs to display')
     parser.add_argument('-n', '--as-numbers', default=None,
                         help='List of comma separated AS numbers to anonymize')
     parser.add_argument('-o', '--output', required=True,
-                        help='Directory to place anonymized files')
+                        help='Output file or directory where anonymized files are placed')
     parser.add_argument('-p', '--anonymize-passwords', action='store_true', default=False,
                         help='Anonymize password and snmp community lines')
     parser.add_argument('-r', '--reserved-words', default=None,
@@ -70,22 +70,20 @@ def main(argv=sys.argv[1:]):
     args = _parse_args(argv)
 
     if not args.input:
-        raise ValueError("Input directory must be specified")
+        raise ValueError("Input must be specified")
 
     if not os.path.exists(args.input):
-        raise ValueError("Input directory does not exist")
+        raise ValueError("Input does not exist")
 
     log_level = logging.getLevelName(args.log_level)
     logging.basicConfig(format='%(levelname)s %(message)s', level=log_level)
 
-    if len(os.listdir(args.input)) == 0:
-        raise ValueError("Input directory is empty")
+    if os.path.isdir(args.input):
+        if len(os.listdir(args.input)) == 0:
+            raise ValueError("Input directory is empty")
 
     if not args.output:
-        raise ValueError("Output directory must be specified")
-
-    if not os.path.exists(args.output):
-        os.makedirs(args.output)
+        raise ValueError("Output must be specified")
 
     if args.undo:
         if args.anonymize_ips:
@@ -112,8 +110,8 @@ def main(argv=sys.argv[1:]):
     if args.sensitive_words is not None:
         sensitive_words = args.sensitive_words.split(',')
 
-    anonymize_files_in_dir(args.input, args.output, args.anonymize_passwords, args.anonymize_ips, args.salt,
-                           args.dump_ip_map, sensitive_words, args.undo, as_numbers, reserved_words)
+    anonymize_files(args.input, args.output, args.anonymize_passwords, args.anonymize_ips, args.salt,
+                    args.dump_ip_map, sensitive_words, args.undo, as_numbers, reserved_words)
 
 
 if __name__ == '__main__':

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -16,7 +16,6 @@
 from __future__ import absolute_import
 import configargparse
 import logging
-import os
 import sys
 
 from .anonymize_files import anonymize_files

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -72,22 +72,11 @@ def main(argv=sys.argv[1:]):
     if not args.input:
         raise ValueError("Input must be specified")
 
-    if not os.path.exists(args.input):
-        raise ValueError("Input does not exist")
-
     log_level = logging.getLevelName(args.log_level)
     logging.basicConfig(format='%(levelname)s %(message)s', level=log_level)
 
     if not args.output:
         raise ValueError("Output must be specified")
-
-    if os.path.isdir(args.input):
-        if len(os.listdir(args.input)) == 0:
-            raise ValueError("Input directory is empty")
-    else:
-        if (not os.path.basename(args.output) or
-                (os.path.exists(args.output) and os.path.isdir(args.output))):
-            raise ValueError("Output must be a file if input is a file")
 
     if args.undo:
         if args.anonymize_ips:

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -78,12 +78,16 @@ def main(argv=sys.argv[1:]):
     log_level = logging.getLevelName(args.log_level)
     logging.basicConfig(format='%(levelname)s %(message)s', level=log_level)
 
+    if not args.output:
+        raise ValueError("Output must be specified")
+
     if os.path.isdir(args.input):
         if len(os.listdir(args.input)) == 0:
             raise ValueError("Input directory is empty")
-
-    if not args.output:
-        raise ValueError("Output must be specified")
+    else:
+        if (not os.path.basename(args.output) or
+                (os.path.exists(args.output) and os.path.isdir(args.output))):
+            raise ValueError("Output must be a file if input is a file")
 
     if args.undo:
         if args.anonymize_ips:

--- a/tests/unit/test_anonymize_files.py
+++ b/tests/unit/test_anonymize_files.py
@@ -15,6 +15,8 @@
 
 import os
 
+import pytest
+
 from netconan.anonymize_files import anonymize_files
 
 
@@ -37,6 +39,58 @@ _SENSITIVE_WORDS = [
     "intentionet",
     "sensitive",
 ]
+
+
+def test_anonymize_files_bad_input_empty(tmpdir):
+    """Test anonymize_files with empty input dir."""
+    input_dir = tmpdir.mkdir("input")
+    output_dir = tmpdir.mkdir("output")
+
+    with pytest.raises(ValueError, match='Input directory is empty'):
+        anonymize_files(str(input_dir), str(output_dir), True, True, salt=_SALT,
+                        sensitive_words=_SENSITIVE_WORDS)
+
+
+def test_anonymize_files_bad_input_missing(tmpdir):
+    """Test anonymize_files with non-existent input."""
+    filename = "test.txt"
+    input_file = tmpdir.join(filename)
+
+    output_file = tmpdir.mkdir("out").join(filename)
+
+    with pytest.raises(ValueError, match='Input does not exist'):
+        anonymize_files(str(input_file), str(output_file), True, True,
+                        salt=_SALT,
+                        sensitive_words=_SENSITIVE_WORDS)
+
+
+def test_anonymize_files_bad_output_file(tmpdir):
+    """Test anonymize_files when output 'file' already exists but is a dir."""
+    filename = "test.txt"
+    input_file = tmpdir.join(filename)
+    input_file.write(_INPUT_CONTENTS)
+
+    output_file = tmpdir.mkdir("out").mkdir(filename)
+
+    with pytest.raises(ValueError, match='Cannot write output file.*'):
+        anonymize_files(str(input_file), str(output_file), True, True,
+                        salt=_SALT,
+                        sensitive_words=_SENSITIVE_WORDS)
+
+
+def test_anonymize_files_bad_output_dir(tmpdir):
+    """Test anonymize_files when output 'dir' already exists but is a file."""
+    filename = "test.txt"
+    input_dir = tmpdir.mkdir("input")
+    input_dir.join(filename).write(_INPUT_CONTENTS)
+
+    output_file = tmpdir.join("out")
+    output_file.write('blah')
+
+    with pytest.raises(ValueError, match='Output path must be a directory.*'):
+        anonymize_files(str(input_dir), str(output_file), True, True,
+                        salt=_SALT,
+                        sensitive_words=_SENSITIVE_WORDS)
 
 
 def test_anonymize_files_dir(tmpdir):

--- a/tests/unit/test_anonymize_files.py
+++ b/tests/unit/test_anonymize_files.py
@@ -13,10 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import filecmp
-
 import os
-import pytest
 
 from netconan.anonymize_files import anonymize_files
 
@@ -42,17 +39,7 @@ _SENSITIVE_WORDS = [
 ]
 
 
-@pytest.fixture()
-def ref_file(tmpdir):
-    """Create and return path to ref file."""
-    ref_file_path = os.path.join(str(tmpdir), "ref.txt")
-    with open(ref_file_path, 'w') as f:
-        f.write(_REF_CONTENTS)
-        f.flush()
-        yield ref_file_path
-
-
-def test_anonymize_files_dir(tmpdir, ref_file):
+def test_anonymize_files_dir(tmpdir):
     """Test anonymize_files with a file in root of input dir."""
     filename = "test.txt"
     input_dir = tmpdir.mkdir("input")
@@ -64,11 +51,12 @@ def test_anonymize_files_dir(tmpdir, ref_file):
     anonymize_files(str(input_dir), str(output_dir), True, True, salt=_SALT,
                     sensitive_words=_SENSITIVE_WORDS)
 
-    # Make sure output file matches the ref
-    assert(filecmp.cmp(str(ref_file), str(output_file)))
+    # Make sure output file exists and matches the ref
+    assert(os.path.isfile(str(output_file)))
+    assert(read_file(str(output_file)) == _REF_CONTENTS)
 
 
-def test_anonymize_files_dir_skip_hidden(tmpdir, ref_file):
+def test_anonymize_files_dir_skip_hidden(tmpdir):
     """Test that file starting with '.' is skipped."""
     filename = ".test.txt"
     input_dir = tmpdir.mkdir("input")
@@ -85,7 +73,7 @@ def test_anonymize_files_dir_skip_hidden(tmpdir, ref_file):
     assert(not os.path.exists(str(output_file)))
 
 
-def test_anonymize_files_dir_nested(tmpdir, ref_file):
+def test_anonymize_files_dir_nested(tmpdir):
     """Test anonymize_files with a file in a nested dir i.e. not at root of input dir."""
     filename = "test.txt"
     input_dir = tmpdir.mkdir("input")
@@ -97,11 +85,12 @@ def test_anonymize_files_dir_nested(tmpdir, ref_file):
     anonymize_files(str(input_dir), str(output_dir), True, True, salt=_SALT,
                     sensitive_words=_SENSITIVE_WORDS)
 
-    # Make sure output file matches the ref
-    assert(filecmp.cmp(str(ref_file), str(output_file)))
+    # Make sure output file exists and matches the ref
+    assert(os.path.isfile(str(output_file)))
+    assert(read_file(str(output_file)) == _REF_CONTENTS)
 
 
-def test_anonymize_files_file(tmpdir, ref_file):
+def test_anonymize_files_file(tmpdir):
     """Test anonymize_files with input file instead of dir."""
     filename = "test.txt"
     input_file = tmpdir.join(filename)
@@ -112,5 +101,12 @@ def test_anonymize_files_file(tmpdir, ref_file):
     anonymize_files(str(input_file), str(output_file), True, True, salt=_SALT,
                     sensitive_words=_SENSITIVE_WORDS)
 
-    # Make sure output file matches the ref
-    assert(filecmp.cmp(str(ref_file), str(output_file)))
+    # Make sure output file exists and matches the ref
+    assert(os.path.isfile(str(output_file)))
+    assert(read_file(str(output_file)) == _REF_CONTENTS)
+
+
+def read_file(file_path):
+    """Read and return contents of file at specified path."""
+    with open(file_path, 'r') as f:
+        return f.read()

--- a/tests/unit/test_anonymize_files.py
+++ b/tests/unit/test_anonymize_files.py
@@ -1,0 +1,116 @@
+"""Test file anonymization."""
+#   Copyright 2018 Intentionet
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import filecmp
+
+import os
+import pytest
+
+from netconan.anonymize_files import anonymize_files
+
+
+_INPUT_CONTENTS = """
+# Intentionet's sensitive test file
+ip address 192.168.2.1 255.255.255.255
+my hash is $1$salt$ABCDEFGHIJKLMNOPQRS
+password foobar
+
+"""
+_REF_CONTENTS = """
+# 1cbbc2's fd8607 test file
+ip address 201.235.139.13 255.255.255.255
+my hash is $1$0000$CxUUGIrqPb7GaB5midrQZ.
+password netconanRemoved1
+
+"""
+_SALT = "TESTSALT"
+_SENSITIVE_WORDS = [
+    "intentionet",
+    "sensitive",
+]
+
+
+@pytest.fixture()
+def ref_file(tmpdir):
+    """Create and return path to ref file."""
+    ref_file_path = os.path.join(str(tmpdir), "ref.txt")
+    with open(ref_file_path, 'w') as f:
+        f.write(_REF_CONTENTS)
+        f.flush()
+        yield ref_file_path
+
+
+def test_anonymize_files_dir(tmpdir, ref_file):
+    """Test anonymize_files with a file in root of input dir."""
+    filename = "test.txt"
+    input_dir = tmpdir.mkdir("input")
+    input_dir.join(filename).write(_INPUT_CONTENTS)
+
+    output_dir = tmpdir.mkdir("output")
+    output_file = output_dir.join(filename)
+
+    anonymize_files(str(input_dir), str(output_dir), True, True, salt=_SALT,
+                    sensitive_words=_SENSITIVE_WORDS)
+
+    # Make sure output file matches the ref
+    assert(filecmp.cmp(str(ref_file), str(output_file)))
+
+
+def test_anonymize_files_dir_skip_hidden(tmpdir, ref_file):
+    """Test that file starting with '.' is skipped."""
+    filename = ".test.txt"
+    input_dir = tmpdir.mkdir("input")
+    input_file = input_dir.join(filename)
+    input_file.write(_INPUT_CONTENTS)
+
+    output_dir = tmpdir.mkdir("output")
+    output_file = output_dir.join(filename)
+
+    anonymize_files(str(input_dir), str(output_dir), True, True, salt=_SALT,
+                    sensitive_words=_SENSITIVE_WORDS)
+
+    # Make sure output file does not exist
+    assert(not os.path.exists(str(output_file)))
+
+
+def test_anonymize_files_dir_nested(tmpdir, ref_file):
+    """Test anonymize_files with a file in a nested dir i.e. not at root of input dir."""
+    filename = "test.txt"
+    input_dir = tmpdir.mkdir("input")
+    input_dir.mkdir("subdir").join(filename).write(_INPUT_CONTENTS)
+
+    output_dir = tmpdir.mkdir("output")
+    output_file = output_dir.join("subdir").join(filename)
+
+    anonymize_files(str(input_dir), str(output_dir), True, True, salt=_SALT,
+                    sensitive_words=_SENSITIVE_WORDS)
+
+    # Make sure output file matches the ref
+    assert(filecmp.cmp(str(ref_file), str(output_file)))
+
+
+def test_anonymize_files_file(tmpdir, ref_file):
+    """Test anonymize_files with input file instead of dir."""
+    filename = "test.txt"
+    input_file = tmpdir.join(filename)
+    input_file.write(_INPUT_CONTENTS)
+
+    output_file = tmpdir.mkdir("out").join(filename)
+
+    anonymize_files(str(input_file), str(output_file), True, True, salt=_SALT,
+                    sensitive_words=_SENSITIVE_WORDS)
+
+    # Make sure output file matches the ref
+    assert(filecmp.cmp(str(ref_file), str(output_file)))


### PR DESCRIPTION
Previously `Netconan` could only anonymize files in the root of the specified input directory.

This PR updates `Netconan` to:
* Allow individual files to be passed in for `input` and `output`
* Recursively process `input` directory

With a dir structure of:
```
anon/
configs/
    sensitive1/
        cisco.cfg
        juniper.cfg
    sensitive2/
        palo_alto.cfg
```
Now, the following is possible:
* `netconan -i configs/sensitive1/cisco.cfg -o anon/cisco_anon.cfg -p -a`
  * anonymizes only the cisco.cfg and saves it at anon/cisco_anon.cfg
* `netconan -i configs -o anon -p -a`
  * anonymizes and saves all three files under anon/, preserving original dir structure
 
Fixes https://github.com/intentionet/netconan/issues/60 and https://github.com/intentionet/netconan/issues/78

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/90)
<!-- Reviewable:end -->
