### PR TITLE
Save more context surrounding sensitive lines

### DIFF
--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -302,7 +302,7 @@ def _extract_enclosing_text(in_val, head='', tail=''):
 
     if val != in_val:
         return _extract_enclosing_text(val, head, tail)
-    return head, val.strip(), tail
+    return head, val, tail
 
 
 def generate_default_sensitive_item_regexes():

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -495,6 +495,17 @@ def test_pwd_removal_preserve_reserved_word(regexes, config_line):
     assert (config_line == replace_matching_item(regexes, config_line, pwd_lookup))
 
 
+@pytest.mark.parametrize('config_line, anon_line', [
+    ('"key": "password FOOBAR",', '"key": "password netconanRemoved0",'),
+    ('"key": "cable shared-secret FOOBAR"', '"key": "! Sensitive line SCRUBBED by netconan"'),
+    ('password "FOOBAR";', 'password "netconanRemoved0";'),
+])
+def test_pwd_removal_preserve_context(regexes, config_line, anon_line):
+    """Test that context is preserved for anonymized lines."""
+    pwd_lookup = {}
+    assert (anon_line == replace_matching_item(regexes, config_line, pwd_lookup))
+
+
 @pytest.mark.parametrize('whitespace', [
     ' ',
     '\t',

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -493,6 +493,7 @@ def test_pwd_removal_and_preserve_reserved_word(regexes, config_line, sensitive_
     'set community p2p',
     'digest secret snmp',
     'password {',
+    'password "ip"',
 ])
 def test_pwd_removal_preserve_reserved_word(regexes, config_line):
     """Test that reserved words are preserved even if they appear in password lines."""

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -397,6 +397,7 @@ def test__check_sensitive_item_format(val, format_):
     item_format = _check_sensitive_item_format(val)
     assert(item_format == format_)
 
+
 @pytest.mark.parametrize('raw_val', unique_passwords)
 @pytest.mark.parametrize('head_text', [
     '\'',
@@ -407,6 +408,7 @@ def test__check_sensitive_item_format(val, format_):
     '[ ',
     '"[\'[',
     '" [',
+    '{',
 ])
 def test__extract_enclosing_text_head(raw_val, head_text):
     """Test extraction of leading text."""
@@ -432,6 +434,7 @@ def test__extract_enclosing_text_head(raw_val, head_text):
     ',',
     '"],',
     '] ;',
+    '}',
 ])
 def test__extract_enclosing_text_tail(raw_val, tail_text):
     """Test extraction of trailing text."""
@@ -469,7 +472,8 @@ def test_pwd_removal(regexes, config_line, sensitive_text):
     """Test removal of passwords and communities from config lines."""
     config_line = config_line.format(sensitive_text)
     pwd_lookup = {}
-    assert(sensitive_text not in replace_matching_item(regexes, config_line, pwd_lookup))
+    assert(sensitive_text not in replace_matching_item(
+        regexes, config_line, pwd_lookup))
 
 
 @pytest.mark.parametrize('config_line, sensitive_text', [
@@ -480,7 +484,8 @@ def test_pwd_removal_and_preserve_reserved_word(regexes, config_line, sensitive_
     """Test removal of passwords when reserved words must be skipped."""
     config_line = config_line.format(sensitive_text)
     pwd_lookup = {}
-    assert(sensitive_text not in replace_matching_item(regexes, config_line, pwd_lookup))
+    assert(sensitive_text not in replace_matching_item(
+        regexes, config_line, pwd_lookup))
 
 
 @pytest.mark.parametrize('config_line', [
@@ -492,18 +497,20 @@ def test_pwd_removal_and_preserve_reserved_word(regexes, config_line, sensitive_
 def test_pwd_removal_preserve_reserved_word(regexes, config_line):
     """Test that reserved words are preserved even if they appear in password lines."""
     pwd_lookup = {}
-    assert (config_line == replace_matching_item(regexes, config_line, pwd_lookup))
+    assert (config_line == replace_matching_item(
+        regexes, config_line, pwd_lookup))
 
 
 @pytest.mark.parametrize('config_line, anon_line', [
     ('"key": "password FOOBAR",', '"key": "password netconanRemoved0",'),
-    ('"key": "cable shared-secret FOOBAR"', '"key": "! Sensitive line SCRUBBED by netconan"'),
+    ('{"key": "cable shared-secret FOOBAR"}', '{"key": "! Sensitive line SCRUBBED by netconan"}'),
     ('password "FOOBAR";', 'password "netconanRemoved0";'),
 ])
 def test_pwd_removal_preserve_context(regexes, config_line, anon_line):
-    """Test that context is preserved for anonymized lines."""
+    """Test that context is preserved replacing/removing passwords."""
     pwd_lookup = {}
-    assert (anon_line == replace_matching_item(regexes, config_line, pwd_lookup))
+    assert (anon_line == replace_matching_item(
+        regexes, config_line, pwd_lookup))
 
 
 @pytest.mark.parametrize('whitespace', [


### PR DESCRIPTION
* Preserve leading and trailing context around sensitive lines (e.g. `{`, `;`, ...)
  * Note: this err's on the side of preserving too much text if a password legitimately ends in special characters (e.g. if the password is literally `password,"`, the `,"` will not be anonymized)
* Moved reserved word checking inside `anonymize_value`, so it now occurs after extracting enclosing text
* Move around some debug statements and add a little more debug info
* Update enclosing text extraction to check leading and trailing separately

Fixes #102 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/104)
<!-- Reviewable:end -->
