### PR TITLE
Update password removal test

### DIFF
--- a/netconan/default_pwd_regexes.py
+++ b/netconan/default_pwd_regexes.py
@@ -43,6 +43,9 @@
 #       extract and replace just the sensitive information
 #  2. sensitive item regex-match-index
 #       note that if this is None, any matching config line will be removed
+# TODO(https://github.com/intentionet/netconan/issues/107)
+# Some of these regexes need to be updated to support quote enclosed passwords
+# which is allowed for at least some syntax on Juniper devices
 default_pwd_line_regexes = [
     [(r'((password|passwd)( level \d+)?( \d+)?) \K(\S+)', 5)],
     [(r'(username( \S+)+ (password|secret)( \d| sha512)?) \K(\S+)', 5)],

--- a/netconan/default_pwd_regexes.py
+++ b/netconan/default_pwd_regexes.py
@@ -43,6 +43,7 @@
 #       extract and replace just the sensitive information
 #  2. sensitive item regex-match-index
 #       note that if this is None, any matching config line will be removed
+#
 # TODO(https://github.com/intentionet/netconan/issues/107)
 # Some of these regexes need to be updated to support quote enclosed passwords
 # which is allowed for at least some syntax on Juniper devices

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -55,6 +55,8 @@ _IGNORED_COMMUNITIES = (r'((\d+|{additive}|{colon}|{list}|{well_known})(?!\S))'
                                 list=_IGNORED_COMM_LIST,
                                 well_known=_IGNORED_COMM_WELL_KNOWN))
 
+_LINE_SCRUBBED_MESSAGE = '! Sensitive line SCRUBBED by netconan'
+
 # Text that is allowed to surround passwords, to be preserved
 _PASSWORD_ENCLOSING_TEXT = ['\\\'', '\\"', '\'', '"', ' ']
 _PASSWORD_ENCLOSING_HEAD_TEXT = _PASSWORD_ENCLOSING_TEXT + ['[', '{']
@@ -65,7 +67,7 @@ _PASSWORD_ENCLOSING_TAIL_TEXT = _PASSWORD_ENCLOSING_TEXT + [']', '}', ';', ',']
 extra_password_regexes = [
     [(r'encrypted-password \K(\S+)', None)],
     [(r'key "\K([^"]+)', 1)],
-    [(r'key-hash sha256 (\S+)', 1)],
+    [(r'key-hash sha256 \K(\S+)', 1)],
     # Replace communities that do not look like well-known BGP communities
     # i.e. snmp communities
     [(r'set community \K((?!{ignore})\S+)'
@@ -343,7 +345,7 @@ def replace_matching_item(compiled_regexes, input_line, pwd_lookup, reserved_wor
                     ' unsupported, so removing this line completely',
                     compiled_re.pattern)
                 output_line = compiled_re.sub(
-                    '! Sensitive line SCRUBBED by netconan', output_line)
+                    _LINE_SCRUBBED_MESSAGE, output_line)
                 break
 
             anon_val = _anonymize_value(match.group(sensitive_item_num), pwd_lookup, reserved_words)

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -115,6 +115,8 @@ juniper_password_lines = [
     ('set system login user admin authentication encrypted-password "{}"', '$1$67Q0XA3z$YqiBW/xxKWr74oHPXEkIv1'),
     ('set system login user someone authenitcation "{}"', '$1$CNANTest$xAfu6Am1d5D/.6OVICuOu/'),
     ('set system license keys key "{}"', 'SOMETHING'),
+    # Does not pass yet, see TODO(https://github.com/intentionet/netconan/issues/107)
+    pytest.param('set system license keys key "{}"', 'SOMETHING sensitive', marks=pytest.mark.skip()),
     ('set snmp community {} authorization read-only', 'SECRETTEXT'),
     ('set snmp trap-group {} otherstuff', 'SECRETTEXT'),
     ('key hexadecimal {}', 'ABCDEF123456'),

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -14,16 +14,16 @@
 #   limitations under the License.
 
 from netconan.sensitive_item_removal import (
-    replace_matching_item, generate_default_sensitive_item_regexes,
-    SensitiveWordAnonymizer, _sensitive_item_formats,
-    _anonymize_value, _check_sensitive_item_format, _extract_enclosing_text)
+    _anonymize_value, _check_sensitive_item_format, _extract_enclosing_text,
+    _LINE_SCRUBBED_MESSAGE, _sensitive_item_formats,
+    generate_default_sensitive_item_regexes, replace_matching_item,
+    SensitiveWordAnonymizer)
 import pytest
 
 # Tuple format is config_line, sensitive_text (should not be in output line)
 # TODO(https://github.com/intentionet/netconan/issues/3):
 # Add in additional test lines (these are just first pass from IOS)
 cisco_password_lines = [
-    ('     password   0      \t{}', 'RemoveMe'),
     (' password 7 {}', '122A00190102180D3C2E'),
     ('username Someone password 0 {}', 'RemoveMe'),
     ('username Someone password {}', 'RemoveMe'),
@@ -114,7 +114,7 @@ juniper_password_lines = [
     ('set system root-authentication encrypted-password "{}"', '$1$CXKwIUfL$6vLSvatE2TCaM25U4u9Bh1'),
     ('set system login user admin authentication encrypted-password "{}"', '$1$67Q0XA3z$YqiBW/xxKWr74oHPXEkIv1'),
     ('set system login user someone authenitcation "{}"', '$1$CNANTest$xAfu6Am1d5D/.6OVICuOu/'),
-    ('set system license keys key "{}"', 'SOMETHING sensitive text here'),
+    ('set system license keys key "{}"', 'SOMETHING'),
     ('set snmp community {} authorization read-only', 'SECRETTEXT'),
     ('set snmp trap-group {} otherstuff', 'SECRETTEXT'),
     ('key hexadecimal {}', 'ABCDEF123456'),
@@ -373,13 +373,28 @@ def test__extract_enclosing_text(val, quote):
     assert (head == quote)
 
 
-@pytest.mark.parametrize('config_line,sensitive_text', sensitive_lines)
-def test_pwd_removal(regexes, config_line, sensitive_text):
+@pytest.mark.parametrize('raw_config_line,sensitive_text', sensitive_lines)
+def test_pwd_removal(regexes, raw_config_line, sensitive_text):
     """Test removal of passwords and communities from config lines."""
-    config_line = config_line.format(sensitive_text)
+    config_line = raw_config_line.format(sensitive_text)
     pwd_lookup = {}
+    anon_line = replace_matching_item(regexes, config_line, pwd_lookup)
+    # Make sure the output line does not contain the sensitive text
+    assert(sensitive_text not in anon_line)
+
+    if _LINE_SCRUBBED_MESSAGE not in anon_line:
+        # If the line wasn't "completely scrubbed",
+        # make sure context was preserved
+        anon_val = _anonymize_value(sensitive_text, pwd_lookup, {})
+        assert(anon_line == raw_config_line.format(anon_val))
+
+
+def test_pwd_removal_with_whitespace(regexes):
+    """Test removal of password when a sensitive line contains extra whitespace."""
+    sensitive_text = 'RemoveMe'
+    sensitive_line = '     password   0      \t{}'.format(sensitive_text)
     assert(sensitive_text not in replace_matching_item(
-        regexes, config_line, pwd_lookup))
+        regexes, sensitive_line, {}))
 
 
 @pytest.mark.parametrize('config_line, sensitive_text', [


### PR DESCRIPTION
* Update password removal test to be more explicit about expected outputs
  * Make sure we're not anonymizing too much or too little
* Split out password removal with extra internal whitespace into its own test
* Fix a regex causing too much to be anonymized
* Add TODO about under-anonymization

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/108)
<!-- Reviewable:end -->
