### PR TITLE
Add support for Juniper authentication-key syntax

### DIFF
--- a/netconan/default_pwd_regexes.py
+++ b/netconan/default_pwd_regexes.py
@@ -69,6 +69,7 @@ default_pwd_line_regexes = [
     [(r'(set session-key (in|out)bound ah \d+) \K(\S+)', 3)],
     [(r'(set session-key (in|out)bound esp \d+ cipher?) \K(\S+)', 3),
      (r'(set session-key (in|out)bound esp \d+(( cipher \S+)? authenticator)) \K(\S+)', 5)],
+    [(r'hello-authentication-key \K([^;]+)', 1)],
     # TODO(https://github.com/intentionet/netconan/issues/3):
     # Follow-up on these.  They were just copied from RANCID so currently:
     #   They are untested in general and need cases added for unit tests
@@ -93,7 +94,6 @@ default_pwd_line_regexes = [
     #     (to make sure the regex handles different syntaxes allowed in the line)
     [(r'(\S* )*authentication-key [^ ;]+(.*)', None)],
     [(r'(\S* )*md5 \d+ key [^ ;]+(.*)', None)],
-    [(r'(\S* )*hello-authentication-key [^ ;]+(.*)', None)],
     [(r'(\S* )*(secret|simple-password) [^ ;]+(.*)', None)],
     [(r'(\S* )*encrypted-password [^ ;]+(.*)', None)],
     [(r'(\S* )*ssh-(rsa|dsa) \"(.*)', None)],

--- a/netconan/default_pwd_regexes.py
+++ b/netconan/default_pwd_regexes.py
@@ -73,7 +73,7 @@ default_pwd_line_regexes = [
     [(r'(set session-key (in|out)bound ah \d+) \K(\S+)', 3)],
     [(r'(set session-key (in|out)bound esp \d+ cipher?) \K(\S+)', 3),
      (r'(set session-key (in|out)bound esp \d+(( cipher \S+)? authenticator)) \K(\S+)', 5)],
-    [(r'hello-authentication-key \K([^;]+)', 1)],
+    [(r'(hello-)?authentication-key \K([^;]+)', 2)],
     # TODO(https://github.com/intentionet/netconan/issues/3):
     # Follow-up on these.  They were just copied from RANCID so currently:
     #   They are untested in general and need cases added for unit tests
@@ -96,7 +96,6 @@ default_pwd_line_regexes = [
     #   They just identify lines where sensitive info exists
     #   They need to be tested against config lines generated on a JUNOS router
     #     (to make sure the regex handles different syntaxes allowed in the line)
-    [(r'(\S* )*authentication-key [^ ;]+(.*)', None)],
     [(r'(\S* )*md5 \d+ key [^ ;]+(.*)', None)],
     [(r'(\S* )*(secret|simple-password) [^ ;]+(.*)', None)],
     [(r'(\S* )*encrypted-password [^ ;]+(.*)', None)],

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -120,7 +120,7 @@ juniper_password_lines = [
     ('set snmp community {} authorization read-only', 'SECRETTEXT'),
     ('set snmp trap-group {} otherstuff', 'SECRETTEXT'),
     ('key hexadecimal {}', 'ABCDEF123456'),
-    ('authentication-key "{}"', '$9$i.m5OBEevLz3RSevx7-VwgZj5TFCA0Tz9p'),
+    ('authentication-key "{}";', '$9$i.m5OBEevLz3RSevx7-VwgZj5TFCA0Tz9p'),
     ('hello-authentication-key "{}"', '$9$i.m5OBEevLz3RSevx7-VwgZj5TFCA0Tz9p'),
 ]
 

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -117,7 +117,8 @@ juniper_password_lines = [
     ('set system login user someone authenitcation "{}"', '$1$CNANTest$xAfu6Am1d5D/.6OVICuOu/'),
     ('set system license keys key "{}"', 'SOMETHING sensitive text here'),
     ('set snmp community {} authorization read-only', 'SECRETTEXT'),
-    ('set snmp trap-group {} otherstuff', 'SECRETTEXT')
+    ('set snmp trap-group {} otherstuff', 'SECRETTEXT'),
+    ('hello-authentication-key "{}"', '$9$i.m5OBEevLz3RSevx7-VwgZj5TFCA0Tz9p'),
 ]
 
 # TODO(https://github.com/intentionet/netconan/issues/3):

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -120,6 +120,7 @@ juniper_password_lines = [
     ('set snmp community {} authorization read-only', 'SECRETTEXT'),
     ('set snmp trap-group {} otherstuff', 'SECRETTEXT'),
     ('key hexadecimal {}', 'ABCDEF123456'),
+    ('authentication-key "{}"', '$9$i.m5OBEevLz3RSevx7-VwgZj5TFCA0Tz9p'),
     ('hello-authentication-key "{}"', '$9$i.m5OBEevLz3RSevx7-VwgZj5TFCA0Tz9p'),
 ]
 


### PR DESCRIPTION
Add support for Juniper authentication-key syntax (https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/hello-authentication-key-edit-protocols-isis.html and https://www.juniper.net/documentation/en_US/junos/topics/reference/configuration-statement/authentication-key-edit-protocols-bgp.html)

