### PR TITLE
Preserve private-use IPv4 blocks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ With Netconan, a sensitive input file
     username admin password 7 122A001901
     enable secret 5 $1$wtHI$0rN7R8PKwC30AsCGA77vy.
     !
-    tacacs-server host 10.10.10.10 key pwd1234
+    tacacs-server host 1.2.3.4 key pwd1234
     ip address 10.10.20.30/24
     ip address 2001:2002::9d3b:1
     !
@@ -39,8 +39,8 @@ to produce an output file you can feel comfortable sharing.
     username admin password 7 09424B1D1A0A1913053E012724322D3765
     enable secret 5 $1$0000$EhfXcDfB7iiakW6mwMy1i.
     !
-    tacacs-server host 119.72.192.224 key netconanRemoved2
-    ip address 119.72.218.183/24
+    tacacs-server host 7.227.130.88 key netconanRemoved2
+    ip address 10.72.218.183/24
     ip address cd7e:83e:1eaf:2ada:7535:591e:6d47:a4b8
     !
     route-map e69ceb-to-880ac2 ...
@@ -71,6 +71,8 @@ Netconan attempts to *preserve useful structure*. For example,
 * Netconan preserves prefixes when anonymizing IPv4 and IPv6 addresses: IP addresses with a common prefix before anonymization will share the same prefix length after anonymization. For more information, see J. Xu et al., *On the Design and Performance of Prefix-Preserving IP Traffic Trace Anonymization*, ACM SIGCOMM Workshop on Internet Measurement, 2001 [`link <https://smartech.gatech.edu/bitstream/handle/1853/6573/GIT-CC-01-22.pdf>`_].
 
 * IPv4 classes are preserved.
+
+* Private-use subnets (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be anonymized (with ``--anonymize-private-blocks`` or ``-b``).
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 
@@ -103,6 +105,8 @@ For more information about less commonly-used features, see the Netconan help (`
     optional arguments:
       -h, --help            show this help message and exit
       -a, --anonymize-ips   Anonymize IP addresses
+      -b, --anonymize-private-blocks
+                            Anonymize private IPv4 blocks (e.g. 10.0.0.0/8)
       -c CONFIG, --config CONFIG
                             Config file specifying params
       -d DUMP_IP_MAP, --dump-ip-map DUMP_IP_MAP

--- a/README.rst
+++ b/README.rst
@@ -70,9 +70,7 @@ Netconan attempts to *preserve useful structure*. For example,
 
 * Netconan preserves prefixes when anonymizing IPv4 and IPv6 addresses: IP addresses with a common prefix before anonymization will share the same prefix length after anonymization. For more information, see J. Xu et al., *On the Design and Performance of Prefix-Preserving IP Traffic Trace Anonymization*, ACM SIGCOMM Workshop on Internet Measurement, 2001 [`link <https://smartech.gatech.edu/bitstream/handle/1853/6573/GIT-CC-01-22.pdf>`_].
 
-* IPv4 classes are preserved.
-
-* Private-use subnets (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be anonymized (with ``--anonymize-private-blocks`` or ``-b``).
+* IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overriden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 
@@ -94,7 +92,7 @@ For more information about less commonly-used features, see the Netconan help (`
     usage: netconan [-h] [-a] [-c CONFIG] [-d DUMP_IP_MAP] -i INPUT
                     [-l {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-n AS_NUMBERS] -o
                     OUTPUT [-p] [-r RESERVED_WORDS] [-s SALT] [-u]
-                    [-w SENSITIVE_WORDS]
+                    [-w SENSITIVE_WORDS] [--preserve-prefixes PRESERVE_PREFIXES]
 
     Args that can start with '--' can also be set in a config file (specified via
     -c). If an arg is specified in more than one place, then command line values
@@ -105,8 +103,6 @@ For more information about less commonly-used features, see the Netconan help (`
     optional arguments:
       -h, --help            show this help message and exit
       -a, --anonymize-ips   Anonymize IP addresses
-      -b, --anonymize-private-blocks
-                            Anonymize private IPv4 blocks (e.g. 10.0.0.0/8)
       -c CONFIG, --config CONFIG
                             Config file specifying params
       -d DUMP_IP_MAP, --dump-ip-map DUMP_IP_MAP
@@ -128,3 +124,7 @@ For more information about less commonly-used features, see the Netconan help (`
       -u, --undo            Undo reversible anonymization (must specify salt)
       -w SENSITIVE_WORDS, --sensitive-words SENSITIVE_WORDS
                             List of comma separated keywords to anonymize
+      --preserve-prefix PRESERVE_PREFIXES
+                            List of comma separated IPv4 prefixes to preserve
+                            (overrides default of IPv4 classes and private-use
+                            prefixes)

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -34,7 +34,7 @@ _CHAR_CHOICES = string.ascii_letters + string.digits
 def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
                     salt=None, dumpfile=None, sensitive_words=None,
                     undo_ip_anon=False, as_numbers=None, reserved_words=None,
-                    preserve_private_blocks=False):
+                    preserve_private_blocks=True):
     """Anonymize each file in input and save to output."""
     anonymizer4 = None
     anonymizer6 = None

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -33,7 +33,8 @@ _CHAR_CHOICES = string.ascii_letters + string.digits
 
 def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
                     salt=None, dumpfile=None, sensitive_words=None,
-                    undo_ip_anon=False, as_numbers=None, reserved_words=None):
+                    undo_ip_anon=False, as_numbers=None, reserved_words=None,
+                    preserve_private_blocks=False):
     """Anonymize each file in input and save to output."""
     anonymizer4 = None
     anonymizer6 = None
@@ -55,7 +56,7 @@ def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
     if sensitive_words is not None:
         anonymizer_sensitive_word = SensitiveWordAnonymizer(sensitive_words, salt)
     if anon_ip or undo_ip_anon:
-        anonymizer4 = IpAnonymizer(salt)
+        anonymizer4 = IpAnonymizer(salt, preserve_private_blocks)
         anonymizer6 = IpV6Anonymizer(salt)
     if as_numbers is not None:
         anonymizer_as_num = AsNumberAnonymizer(as_numbers, salt)

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -34,7 +34,7 @@ _CHAR_CHOICES = string.ascii_letters + string.digits
 def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
                     salt=None, dumpfile=None, sensitive_words=None,
                     undo_ip_anon=False, as_numbers=None, reserved_words=None,
-                    preserve_private_blocks=True):
+                    preserve_prefixes=None):
     """Anonymize each file in input and save to output."""
     anonymizer4 = None
     anonymizer6 = None
@@ -56,7 +56,7 @@ def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
     if sensitive_words is not None:
         anonymizer_sensitive_word = SensitiveWordAnonymizer(sensitive_words, salt)
     if anon_ip or undo_ip_anon:
-        anonymizer4 = IpAnonymizer(salt, preserve_private_blocks)
+        anonymizer4 = IpAnonymizer(salt, preserve_prefixes)
         anonymizer6 = IpV6Anonymizer(salt)
     if as_numbers is not None:
         anonymizer_as_num = AsNumberAnonymizer(as_numbers, salt)

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -164,14 +164,13 @@ class IpAnonymizer(_BaseIpAnonymizer):
         if preserve_private:
             # Preserve private blocks
             for block in IpAnonymizer._PRIVATE_BLOCKS:
-                # Cache all shared prefixes to prevent collisions
+                # Cache prefixes shared w/ private blocks to prevent collisions
                 for position in range(len(block)):
                     value = block[:position]
                     if value + '0' not in self.cache:
                         self.cache[value + '0'] = value + '0'
                     if value + '1' not in self.cache:
                         self.cache[value + '1'] = value + '1'
-
 
     def _is_mask(self, possible_mask_int):
         """Return True if the input int can be used as a 32-bit prefix mask.

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -146,16 +146,6 @@ class IpAnonymizer(_BaseIpAnonymizer):
     """An anonymizer for IPv4 addresses."""
 
     _DROP_ZEROS_PATTERN = regex.compile(r'0*(\d+)\.0*(\d+)\.0*(\d+)\.0*(\d+)')
-    _DEFAULT_PRESERVED_SUBNETS2 = (
-        '0',                    # Class A
-        '10',                   # Class B
-        '110',                  # Class C
-        '1110',                 # Class D and implies class E
-                                # Private-use subnets
-        '00001010',             # 10.0.0.0/8
-        '101011000001',         # 172.16.0.0/12
-        '1100000010101000',     # 192.168.0.0/16
-    )
     _DEFAULT_PRESERVED_PREFIXES = (
         '0.0.0.0/1',        # Class A
         '128.0.0.0/2',      # Class B

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -13,6 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from __future__ import unicode_literals
 from abc import ABCMeta, abstractmethod
 
 from bidict import bidict
@@ -145,8 +146,7 @@ class _BaseIpAnonymizer(object):
 class IpAnonymizer(_BaseIpAnonymizer):
     """An anonymizer for IPv4 addresses."""
 
-    _DROP_ZEROS_PATTERN = regex.compile(r'0*(\d+)\.0*(\d+)\.0*(\d+)\.0*(\d+)')
-    _DEFAULT_PRESERVED_PREFIXES = (
+    DEFAULT_PRESERVED_PREFIXES = (
         '0.0.0.0/1',        # Class A
         '128.0.0.0/2',      # Class B
         '192.0.0.0/3',      # Class C
@@ -155,13 +155,14 @@ class IpAnonymizer(_BaseIpAnonymizer):
         '172.16.0.0/12',    # Private-use subnet
         '192.168.0.0/16',   # Private-use subnet
     )
+    _DROP_ZEROS_PATTERN = regex.compile(r'0*(\d+)\.0*(\d+)\.0*(\d+)\.0*(\d+)')
 
     def __init__(self, salt, preserve_prefixes=None, **kwargs):
         """Create an anonymizer using the specified salt."""
         super(IpAnonymizer, self).__init__(salt, 32, **kwargs)
 
         if preserve_prefixes is None:
-            preserve_prefixes = self._DEFAULT_PRESERVED_PREFIXES
+            preserve_prefixes = self.DEFAULT_PRESERVED_PREFIXES
 
         # Preserve relevant prefixes
         for subnet_str in preserve_prefixes:

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -146,31 +146,41 @@ class IpAnonymizer(_BaseIpAnonymizer):
     """An anonymizer for IPv4 addresses."""
 
     _DROP_ZEROS_PATTERN = regex.compile(r'0*(\d+)\.0*(\d+)\.0*(\d+)\.0*(\d+)')
-    _PRIVATE_BLOCKS = [
+    _DEFAULT_PRESERVED_SUBNETS2 = (
+        '0',                    # Class A
+        '10',                   # Class B
+        '110',                  # Class C
+        '1110',                 # Class D and implies class E
+                                # Private-use subnets
         '00001010',             # 10.0.0.0/8
         '101011000001',         # 172.16.0.0/12
         '1100000010101000',     # 192.168.0.0/16
-    ]
+    )
+    _DEFAULT_PRESERVED_PREFIXES = (
+        '0.0.0.0/1',        # Class A
+        '128.0.0.0/2',      # Class B
+        '192.0.0.0/3',      # Class C
+        '224.0.0.0/4',      # Class D (implies class E)
+        '10.0.0.0/8',       # Private-use subnet
+        '172.16.0.0/12',    # Private-use subnet
+        '192.168.0.0/16',   # Private-use subnet
+    )
 
-    def __init__(self, salt, preserve_private=True, **kwargs):
+    def __init__(self, salt, preserve_prefixes=None, **kwargs):
         """Create an anonymizer using the specified salt."""
         super(IpAnonymizer, self).__init__(salt, 32, **kwargs)
-        # Preserve IPv4 classes
-        for i in range(4):
-            bits = '1' * i
-            self.cache[bits + '1'] = bits + '1'
-            self.cache[bits + '0'] = bits + '0'
 
-        if preserve_private:
-            # Preserve private blocks
-            for block in IpAnonymizer._PRIVATE_BLOCKS:
-                # Cache prefixes shared w/ private blocks to prevent collisions
-                for position in range(len(block)):
-                    value = block[:position]
-                    if value + '0' not in self.cache:
-                        self.cache[value + '0'] = value + '0'
-                    if value + '1' not in self.cache:
-                        self.cache[value + '1'] = value + '1'
+        if preserve_prefixes is None:
+            preserve_prefixes = self._DEFAULT_PRESERVED_PREFIXES
+
+        # Preserve relevant prefixes
+        for subnet_str in preserve_prefixes:
+            subnet = ipaddress.ip_network(subnet_str)
+            prefix_bits = self.fmt.format(int(subnet.network_address))[:subnet.prefixlen]
+            for position in range(len(prefix_bits)):
+                value = prefix_bits[:position]
+                self.cache[value + '0'] = value + '0'
+                self.cache[value + '1'] = value + '1'
 
     def _is_mask(self, possible_mask_int):
         """Return True if the input int can be used as a 32-bit prefix mask.

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -38,9 +38,6 @@ def _parse_args(argv):
 
     parser.add_argument('-a', '--anonymize-ips', action='store_true', default=False,
                         help='Anonymize IP addresses')
-    parser.add_argument('-b', '--anonymize-private-blocks', default=False,
-                        action='store_true',
-                        help='Anonymize private IPv4 blocks (e.g. 10.0.0.0/8)')
     parser.add_argument('-c', '--config', is_config_file=True,
                         help='Config file specifying params')
     parser.add_argument('-d', '--dump-ip-map', default=None,
@@ -64,6 +61,10 @@ def _parse_args(argv):
                         help='Undo reversible anonymization (must specify salt)')
     parser.add_argument('-w', '--sensitive-words', default=None,
                         help='List of comma separated keywords to anonymize')
+    parser.add_argument('--preserve-prefixes', default=None,
+                        help='List of comma separated IPv4 prefixes to preserve'
+                             ' (overrides default of IPv4 classes and private-'
+                             'use prefixes)')
     return parser.parse_args(argv)
 
 
@@ -105,6 +106,10 @@ def main(argv=sys.argv[1:]):
     if args.sensitive_words is not None:
         sensitive_words = args.sensitive_words.split(',')
 
+    preserve_prefixes = None
+    if args.preserve_prefixes is not None:
+        preserve_prefixes = args.preserve_prefixes.split(',')
+
     if not any([
         as_numbers,
         sensitive_words,
@@ -118,7 +123,7 @@ def main(argv=sys.argv[1:]):
         anonymize_files(args.input, args.output, args.anonymize_passwords,
                         args.anonymize_ips, args.salt, args.dump_ip_map,
                         sensitive_words, args.undo, as_numbers, reserved_words,
-                        not args.anonymize_private_blocks)
+                        preserve_prefixes)
 
 
 if __name__ == '__main__':

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -38,6 +38,9 @@ def _parse_args(argv):
 
     parser.add_argument('-a', '--anonymize-ips', action='store_true', default=False,
                         help='Anonymize IP addresses')
+    parser.add_argument('-b', '--anonymize-private-blocks', default=False,
+                        action='store_true',
+                        help='Anonymize private IPv4 blocks (e.g. 10.0.0.0/8)')
     parser.add_argument('-c', '--config', is_config_file=True,
                         help='Config file specifying params')
     parser.add_argument('-d', '--dump-ip-map', default=None,
@@ -114,7 +117,8 @@ def main(argv=sys.argv[1:]):
     else:
         anonymize_files(args.input, args.output, args.anonymize_passwords,
                         args.anonymize_ips, args.salt, args.dump_ip_map,
-                        sensitive_words, args.undo, as_numbers, reserved_words)
+                        sensitive_words, args.undo, as_numbers, reserved_words,
+                        not args.anonymize_private_blocks)
 
 
 if __name__ == '__main__':

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -18,6 +18,7 @@ import configargparse
 import logging
 import sys
 
+from .ip_anonymization import IpAnonymizer
 from .anonymize_files import anonymize_files
 
 
@@ -61,10 +62,9 @@ def _parse_args(argv):
                         help='Undo reversible anonymization (must specify salt)')
     parser.add_argument('-w', '--sensitive-words', default=None,
                         help='List of comma separated keywords to anonymize')
-    parser.add_argument('--preserve-prefixes', default=None,
-                        help='List of comma separated IPv4 prefixes to preserve'
-                             ' (overrides default of IPv4 classes and private-'
-                             'use prefixes)')
+    parser.add_argument('--preserve-prefixes',
+                        default=','.join(IpAnonymizer.DEFAULT_PRESERVED_PREFIXES),
+                        help='List of comma separated IPv4 prefixes to preserve')
     return parser.parse_args(argv)
 
 

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -21,6 +21,7 @@ from netconan.netconan import main
 INPUT_CONTENTS = """
 # Intentionet's sensitive test file
 ip address 192.168.2.1 255.255.255.255
+ip address 1.2.3.4 0.0.0.0
 my hash is $1$salt$ABCDEFGHIJKLMNOPQRS
 AS num 12345 and 65432 should be changed
 password foobar
@@ -30,7 +31,8 @@ password reservedword
 
 REF_CONTENTS = """
 # 1cbbc2's fd8607 test file
-ip address 201.235.139.13 255.255.255.255
+ip address 192.168.139.13 255.255.255.255
+ip address 5.86.28.249 0.0.0.0
 my hash is $1$0000$CxUUGIrqPb7GaB5midrQZ.
 AS num 8625 and 64818 should be changed
 password netconanRemoved1

--- a/tests/unit/test_anonymize_files.py
+++ b/tests/unit/test_anonymize_files.py
@@ -30,7 +30,7 @@ password foobar
 """
 _REF_CONTENTS = """
 # 1cbbc2's fd8607 test file
-ip address 201.235.139.13 255.255.255.255
+ip address 192.168.139.13 255.255.255.255
 my hash is $1$0000$CxUUGIrqPb7GaB5midrQZ.
 password netconanRemoved1
 

--- a/tests/unit/test_ip_anonymization.py
+++ b/tests/unit/test_ip_anonymization.py
@@ -13,13 +13,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from __future__ import unicode_literals
 import ipaddress
 import pytest
 import regex
 
 from netconan.ip_anonymization import (
     IpAnonymizer, IpV6Anonymizer, anonymize_ip_addr, _ensure_unicode)
-from six import u
 
 ip_v4_classes = [
     '0.0.0.0/1',    # Class A
@@ -393,7 +393,7 @@ def test_false_positives(anonymizer_v4, anonymizer_v6, line):
                          ])
 def test_v4_anonymizer_ignores_leading_zeros(anonymizer_v4, zeros, no_zeros):
     """Test that v4 IP address ignore leading zeros & don't interpret octal."""
-    assert(ipaddress.IPv4Address(u(no_zeros)) == anonymizer_v4.make_addr(zeros))
+    assert(ipaddress.IPv4Address(no_zeros) == anonymizer_v4.make_addr(zeros))
 
 
 @pytest.mark.parametrize('ip_int, expected', [

--- a/tests/unit/test_ip_anonymization.py
+++ b/tests/unit/test_ip_anonymization.py
@@ -18,7 +18,7 @@ import pytest
 import regex
 
 from netconan.ip_anonymization import (
-    IpAnonymizer, IpV6Anonymizer, anonymize_ip_addr)
+    IpAnonymizer, IpV6Anonymizer, anonymize_ip_addr, _ensure_unicode)
 from six import u
 
 ip_v4_list = [
@@ -215,7 +215,7 @@ def test_anonymize_private_blocks(anonymizer_v4_anonymize_private_blocks, start,
     ip_int_end = int(anonymizer_v4_anonymize_private_blocks.make_addr(end))
     ip_int_end_anon = anonymizer_v4_anonymize_private_blocks.anonymize(ip_int_end)
 
-    network = ipaddress.ip_network(subnet)
+    network = ipaddress.ip_network(_ensure_unicode(subnet))
 
     # Make sure addresses in the block are not in the block after anonymization
     assert (ipaddress.ip_address(ip_int_start_anon) not in network)
@@ -231,7 +231,7 @@ def test_preserve_private_blocks(anonymizer_v4, start, end, subnet):
     ip_int_end = int(anonymizer_v4.make_addr(end))
     ip_int_end_anon = anonymizer_v4.anonymize(ip_int_end)
 
-    network = ipaddress.ip_network(subnet)
+    network = ipaddress.ip_network(_ensure_unicode(subnet))
 
     # Make sure addresses in the block stay in the block
     assert (ipaddress.ip_address(ip_int_start_anon) in network)

--- a/tests/unit/test_ip_anonymization.py
+++ b/tests/unit/test_ip_anonymization.py
@@ -213,7 +213,7 @@ def test_v4_class_preserved(flip_anonymizer_v4, ip_addr):
     assert(0xFFFFFFFF ^ class_mask == ip_int ^ ip_int_anon)
 
 
-def test_anonymize_custom_prefixes():
+def test_preserve_custom_prefixes():
     """Test that a custom prefix is preserved correctly."""
     subnet = '170.0.0.0/8'
     anonymizer = IpAnonymizer(SALT, [subnet])

--- a/tests/unit/test_ip_anonymization.py
+++ b/tests/unit/test_ip_anonymization.py
@@ -217,7 +217,7 @@ def test_anonymize_private_blocks(anonymizer_v4_anonymize_private_blocks, start,
 
     network = ipaddress.ip_network(subnet)
 
-    # Make sure addresses in the block stay in the block
+    # Make sure addresses in the block are not in the block after anonymization
     assert (ipaddress.ip_address(ip_int_start_anon) not in network)
     assert (ipaddress.ip_address(ip_int_end_anon) not in network)
 


### PR DESCRIPTION
* Preserve private-use IP blocks by default (https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml)
* Add option to anonymize private IP blocks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/112)
<!-- Reviewable:end -->
