### PR TITLE
Unpin regex version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'configargparse', 'bidict', 'enum34', 'ipaddress', 'passlib', 'regex==2019.02.18', 'six'
+        'configargparse', 'bidict', 'enum34', 'ipaddress', 'passlib', 'regex', 'six'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
`regex` import issue fixed now (https://bitbucket.org/mrabarnett/mrab-regex/issues/314/import-error-no-module-named)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/115)
<!-- Reviewable:end -->
