### PR TITLE
Pin all dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,13 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'configargparse', 'bidict', 'enum34', 'ipaddress', 'passlib', 'regex', 'six'
+        'configargparse<1.0.0',
+        'bidict<1.0.0',
+        'enum34<2.0.0',
+        'ipaddress<2.0.0',
+        'passlib<2.0.0',
+        'regex<=2019.6.8',
+        'six<2.0.0'
     ],
 
     # List additional groups of dependencies here (e.g. development
@@ -73,17 +79,22 @@ setup(
     # $ pip install -e .[dev,test]
     extras_require={
         'dev': [
-            'flake8',
-            'flake8-docstrings',
+            'flake8<4.0.0',
+            'flake8-docstrings<2.0.0',
             'pydocstyle<4.0.0'
         ],
         # 'test': ['coverage', 'pytz'],
     },
 
     # List pytest requirements for running unit tests
-    setup_requires=['pytest-runner'],
+    setup_requires=['pytest-runner<6.0'],
     # pytest 5+ does not support Python 2
-    tests_require=['pytest>=4.2.0,<5.0.0', 'pytest-cov', 'requests_mock', 'testfixtures'],
+    tests_require=[
+        'pytest>=4.2.0,<5.0.0',
+        'pytest-cov<3.0.0',
+        'requests_mock<2.0.0',
+        'testfixtures<7.0.0'
+    ],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
Pin all dependencies to less than the next major version (except `regex`, where major version isn't well defined, so just use the most-recent working version on `PyPI` and `conda-forge`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/124)
<!-- Reviewable:end -->
