### PR TITLE
Only use enum34 for Python < 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,20 +72,15 @@ setup(
     # for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        'dev': ['flake8', 'flake8-docstrings'],
+        'dev': ['flake8', 'flake8-docstrings',
+        'pydocstyle<4.0.0'],
         # 'test': ['coverage', 'pytz'],
     },
 
     # List pytest requirements for running unit tests
     setup_requires=['pytest-runner'],
     # pytest 5+ does not support Python 2
-    tests_require=[
-        'pydocstyle<4.0.0',
-        'pytest>=4.2.0,<5.0.0',
-        'pytest-cov',
-        'requests_mock',
-        'testfixtures'
-    ],
+    tests_require=['pytest>=4.2.0,<5.0.0', 'pytest-cov', 'requests_mock', 'testfixtures'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,8 @@ setup(
 
     # List pytest requirements for running unit tests
     setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'pytest-cov', 'requests_mock', 'testfixtures'],
+    # pytest 5+ does not support Python 2
+    tests_require=['pytest>=4.2.0,<5.0.0', 'pytest-cov', 'requests_mock', 'testfixtures'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ https://github.com/pypa/sampleproject
 
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
+from sys import version_info
 from os import path
 
 here = path.abspath(path.dirname(__file__))
@@ -66,12 +67,14 @@ setup(
     install_requires=[
         'configargparse<1.0.0',
         'bidict<1.0.0',
-        'enum34<2.0.0',
         'ipaddress<2.0.0',
         'passlib<2.0.0',
         'regex<=2019.6.8',
         'six<2.0.0'
-    ],
+    ] + (
+        # Only use enum34 for Python older than 3.4
+        ['enum34<2.0.0'] if version_info < (3, 4) else []
+    ),
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,11 @@ setup(
     # for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        'dev': ['flake8', 'flake8-docstrings',
-        'pydocstyle<4.0.0'],
+        'dev': [
+            'flake8',
+            'flake8-docstrings',
+            'pydocstyle<4.0.0'
+        ],
         # 'test': ['coverage', 'pytz'],
     },
 

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,13 @@ setup(
     # List pytest requirements for running unit tests
     setup_requires=['pytest-runner'],
     # pytest 5+ does not support Python 2
-    tests_require=['pytest>=4.2.0,<5.0.0', 'pytest-cov', 'requests_mock', 'testfixtures'],
+    tests_require=[
+        'pydocstyle<4.0.0',
+        'pytest>=4.2.0,<5.0.0',
+        'pytest-cov',
+        'requests_mock',
+        'testfixtures'
+    ],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
Only use `enum34` for Python < 3.4

Addresses https://github.com/intentionet/netconan/issues/122

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/125)
<!-- Reviewable:end -->
