### PR TITLE
Add option to preserve specified network block

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,9 @@ Netconan attempts to *preserve useful structure*. For example,
 * IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overriden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
 
 * Specific IPv4 addresses can optionally be preserved, e.g.
+
   - ``--preserve-private-addresses`` or ``--preserve-rfc-1918`` skips anonymizing addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.
+
   - Alternatively, a specific block of addresses can be preserved with ``--preserve-addresses`` e.g. ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` block and skip anonymizing ``13.12.11.10``.
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).

--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,8 @@ Netconan attempts to *preserve useful structure*. For example,
 
 * IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overriden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
 
+* IPv4 networks can optionally be preserved, e.g. ``--preserve-networks 192.168.0.0/16,172.16.0.0/12,10.0.0.0/8`` preserves all addresses and subnets enclosed in those private-use blocks.
+
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 
 * Standard password and hash formats (salted md5, Cisco Type 7, Juniper Type 9) are recognized and substituted with format-compliant replacements.
@@ -128,3 +130,4 @@ For more information about less commonly-used features, see the Netconan help (`
                             List of comma separated keywords to anonymize
       --preserve-prefixes PRESERVE_PREFIXES
                             List of comma separated IPv4 prefixes to preserve
+      --preserve-networks   List of comma separated IPv4 networks to preserve

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Netconan attempts to *preserve useful structure*. For example,
 
 * IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overriden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
 
-* IPv4 addresses can optionally be preserved, e.g. ``--preserve-private-addresses`` or ``--preserve-rfc-1918`` preserves addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.  Alternatively, a specific block of addresses can be preserved with ``--preserve-networks`` e.g. ``--preserve-networks 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` block and skip anonymizing ``13.12.11.10``.
+* IPv4 addresses can optionally be preserved, e.g. ``--preserve-private-addresses`` or ``--preserve-rfc-1918`` preserves addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.  Alternatively, a specific block of addresses can be preserved with ``--preserve-addresses`` e.g. ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` block and skip anonymizing ``13.12.11.10``.
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 
@@ -134,8 +134,7 @@ For more information about less commonly-used features, see the Netconan help (`
                             bits are still anonymized)
       --preserve-addresses PRESERVE_ADDRESSES
                             List of comma separated IPv4 addresses or networks to
-                            preserve (skip anonymizing the prefix and host bits in
-                            the specified addresses)
+                            preserve (skip anonymizing the specified addresses)
       --preserve-private-addresses, --preserve-rfc-1918
                             Preserve private-use IPv4 addresses (skip anonymizing
                             addresses in 192.168.0.0/16, 172.16.0.0/12, and

--- a/README.rst
+++ b/README.rst
@@ -130,4 +130,5 @@ For more information about less commonly-used features, see the Netconan help (`
                             List of comma separated keywords to anonymize
       --preserve-prefixes PRESERVE_PREFIXES
                             List of comma separated IPv4 prefixes to preserve
-      --preserve-networks   List of comma separated IPv4 networks to preserve
+      --preserve-networks PRESERVE_NETWORKS
+                            List of comma separated IPv4 networks to preserve

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Netconan attempts to *preserve useful structure*. For example,
 
 * IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overriden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
 
-* IPv4 networks can optionally be preserved, e.g. ``--preserve-networks 192.168.0.0/16,172.16.0.0/12,10.0.0.0/8`` preserves all addresses and subnets enclosed in those private-use blocks.
+* IPv4 networks can optionally be preserved, e.g. ``--preserve-private-networks`` or ``--preserve-rfc-1918`` preserves address that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.  Alternatively, a specific block can be preserved with ``--preserve-networks`` e.g. ``--preserve-networks 12.0.0.0/8`` will preserve prefixes and host bits for any address in the ``12.0.0.0/8`` block.
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 
@@ -128,7 +128,15 @@ For more information about less commonly-used features, see the Netconan help (`
       -u, --undo            Undo reversible anonymization (must specify salt)
       -w SENSITIVE_WORDS, --sensitive-words SENSITIVE_WORDS
                             List of comma separated keywords to anonymize
-      --preserve-prefixes PRESERVE_PREFIXES
-                            List of comma separated IPv4 prefixes to preserve
-      --preserve-networks PRESERVE_NETWORKS
-                            List of comma separated IPv4 networks to preserve
+  --preserve-prefixes PRESERVE_PREFIXES
+                        List of comma separated IPv4 prefixes to preserve (do
+                        not anonymize the specified prefixes, but host bits
+                        are still anonymized)
+  --preserve-networks PRESERVE_NETWORKS
+                        List of comma separated IPv4 networks to preserve (do
+                        not anonymize the prefix or host bits in the specified
+                        blocks)
+  --preserve-private-networks, --preserve-rfc-1918
+                        Preserve private-use IPv4 networks (do not anonymize
+                        the prefix or host bits for addresses in
+                        192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8)

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,9 @@ Netconan attempts to *preserve useful structure*. For example,
 
 * IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overriden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
 
-* IPv4 addresses can optionally be preserved, e.g. ``--preserve-private-addresses`` or ``--preserve-rfc-1918`` preserves addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.  Alternatively, a specific block of addresses can be preserved with ``--preserve-addresses`` e.g. ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` block and skip anonymizing ``13.12.11.10``.
+* Specific IPv4 addresses can optionally be preserved, e.g.
+  * ``--preserve-private-addresses`` or ``--preserve-rfc-1918`` skips anonymizing addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.
+  * Alternatively, a specific block of addresses can be preserved with ``--preserve-addresses`` e.g. ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` block and skip anonymizing ``13.12.11.10``.
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 

--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,9 @@ Netconan attempts to *preserve useful structure*. For example,
 
 * Specific addresses can optionally be preserved, e.g.
 
-  - ``--preserve-private-addresses`` skips anonymizing addresses that fall under private-use blocks defined in `RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.
-
   - ``--preserve-addresses`` skips anonymizing the specified network or address e.g. ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` network and skip anonymizing ``13.12.11.10``.
+
+  - ``--preserve-private-addresses`` skips anonymizing addresses that fall under private-use blocks.
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 
@@ -136,12 +136,17 @@ For more information about less commonly-used features, see the Netconan help (`
                             List of comma separated IP prefixes to preserve.
                             Specified prefixes are preserved, but the host bits
                             within those prefixes are still anonymized. To
-                            preserve the entire network block, use --preserve-
-                            addresses instead
+                            preserve prefixes and host bits in specified blocks,
+                            use --preserve-addresses instead
       --preserve-addresses PRESERVE_ADDRESSES
                             List of comma separated IP addresses or networks to
-                            preserve
+                            preserve. Prefixes and host bits within those networks
+                            are preserved. To preserve just prefixes and anonymize
+                            host bits, use --preserve-prefixes
       --preserve-private-addresses
-                            Preserve private-use IP addresses (skip anonymizing
-                            addresses in 192.168.0.0/16, 172.16.0.0/12, and
-                            10.0.0.0/8)
+                            Preserve private-use IP addresses. Prefixes and host
+                            bits within the private-use IP networks are preserved.
+                            To preserve specific addresses or networks, use
+                            --preserve-addresses instead. To preserve just
+                            prefixes and anonymize host bits, use --preserve-
+                            prefixes

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Netconan attempts to *preserve useful structure*. For example,
 
 * IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overriden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
 
-* IPv4 networks can optionally be preserved, e.g. ``--preserve-private-networks`` or ``--preserve-rfc-1918`` preserves addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.  Alternatively, a specific block of addresses can be preserved with ``--preserve-networks`` e.g. ``--preserve-networks 12.0.0.0/8`` will skip anonymization for any address in the ``12.0.0.0/8`` block.
+* IPv4 addresses can optionally be preserved, e.g. ``--preserve-private-addresses`` or ``--preserve-rfc-1918`` preserves addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.  Alternatively, a specific block of addresses can be preserved with ``--preserve-networks`` e.g. ``--preserve-networks 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` block and skip anonymizing ``13.12.11.10``.
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 
@@ -128,15 +128,15 @@ For more information about less commonly-used features, see the Netconan help (`
       -u, --undo            Undo reversible anonymization (must specify salt)
       -w SENSITIVE_WORDS, --sensitive-words SENSITIVE_WORDS
                             List of comma separated keywords to anonymize
-  --preserve-prefixes PRESERVE_PREFIXES
-                        List of comma separated IPv4 prefixes to preserve
-                        (skip anonymizing the specified prefixes, but host
-                        bits are still anonymized)
-  --preserve-networks PRESERVE_NETWORKS
-                        List of comma separated IPv4 networks to preserve
-                        (skip anonymizing the prefix and host bits in the
-                        specified blocks)
-  --preserve-private-networks, --preserve-rfc-1918
-                        Preserve private-use IPv4 networks (skip anonymizing
-                        the prefix or host bits for addresses in
-                        192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8)
+      --preserve-prefixes PRESERVE_PREFIXES
+                            List of comma separated IPv4 prefixes to preserve
+                            (skip anonymizing the specified prefixes, but host
+                            bits are still anonymized)
+      --preserve-addresses PRESERVE_ADDRESSES
+                            List of comma separated IPv4 addresses or networks to
+                            preserve (skip anonymizing the prefix and host bits in
+                            the specified addresses)
+      --preserve-private-addresses, --preserve-rfc-1918
+                            Preserve private-use IPv4 addresses (skip anonymizing
+                            addresses in 192.168.0.0/16, 172.16.0.0/12, and
+                            10.0.0.0/8)

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Netconan attempts to *preserve useful structure*. For example,
 
   - ``--preserve-private-addresses`` or ``--preserve-rfc-1918`` skips anonymizing addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.
 
-  - Alternatively, a specific block of addresses can be preserved with ``--preserve-addresses`` e.g. ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` block and skip anonymizing ``13.12.11.10``.
+  - ``--preserve-addresses`` skips anonymizing the specified network or address e.g. ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` network and skip anonymizing ``13.12.11.10``.
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 

--- a/README.rst
+++ b/README.rst
@@ -73,8 +73,8 @@ Netconan attempts to *preserve useful structure*. For example,
 * IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overriden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
 
 * Specific IPv4 addresses can optionally be preserved, e.g.
-  * ``--preserve-private-addresses`` or ``--preserve-rfc-1918`` skips anonymizing addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.
-  * Alternatively, a specific block of addresses can be preserved with ``--preserve-addresses`` e.g. ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` block and skip anonymizing ``13.12.11.10``.
+  - ``--preserve-private-addresses`` or ``--preserve-rfc-1918`` skips anonymizing addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.
+  - Alternatively, a specific block of addresses can be preserved with ``--preserve-addresses`` e.g. ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` block and skip anonymizing ``13.12.11.10``.
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Netconan attempts to *preserve useful structure*. For example,
 
 * IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overriden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
 
-* IPv4 networks can optionally be preserved, e.g. ``--preserve-private-networks`` or ``--preserve-rfc-1918`` preserves address that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.  Alternatively, a specific block can be preserved with ``--preserve-networks`` e.g. ``--preserve-networks 12.0.0.0/8`` will preserve prefixes and host bits for any address in the ``12.0.0.0/8`` block.
+* IPv4 networks can optionally be preserved, e.g. ``--preserve-private-networks`` or ``--preserve-rfc-1918`` preserves addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.  Alternatively, a specific block of addresses can be preserved with ``--preserve-networks`` e.g. ``--preserve-networks 12.0.0.0/8`` will skip anonymization for any address in the ``12.0.0.0/8`` block.
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 
@@ -129,14 +129,14 @@ For more information about less commonly-used features, see the Netconan help (`
       -w SENSITIVE_WORDS, --sensitive-words SENSITIVE_WORDS
                             List of comma separated keywords to anonymize
   --preserve-prefixes PRESERVE_PREFIXES
-                        List of comma separated IPv4 prefixes to preserve (do
-                        not anonymize the specified prefixes, but host bits
-                        are still anonymized)
+                        List of comma separated IPv4 prefixes to preserve
+                        (skip anonymizing the specified prefixes, but host
+                        bits are still anonymized)
   --preserve-networks PRESERVE_NETWORKS
-                        List of comma separated IPv4 networks to preserve (do
-                        not anonymize the prefix or host bits in the specified
-                        blocks)
+                        List of comma separated IPv4 networks to preserve
+                        (skip anonymizing the prefix and host bits in the
+                        specified blocks)
   --preserve-private-networks, --preserve-rfc-1918
-                        Preserve private-use IPv4 networks (do not anonymize
+                        Preserve private-use IPv4 networks (skip anonymizing
                         the prefix or host bits for addresses in
                         192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8)

--- a/README.rst
+++ b/README.rst
@@ -72,9 +72,9 @@ Netconan attempts to *preserve useful structure*. For example,
 
 * IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overriden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
 
-* Specific IPv4 addresses can optionally be preserved, e.g.
+* Specific addresses can optionally be preserved, e.g.
 
-  - ``--preserve-private-addresses`` or ``--preserve-rfc-1918`` skips anonymizing addresses that fall under `private-use IPv4 blocks defined in RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.
+  - ``--preserve-private-addresses`` skips anonymizing addresses that fall under private-use blocks defined in `RFC 1918 <https://tools.ietf.org/html/rfc1918#section-3>`_.
 
   - ``--preserve-addresses`` skips anonymizing the specified network or address e.g. ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` network and skip anonymizing ``13.12.11.10``.
 
@@ -133,13 +133,15 @@ For more information about less commonly-used features, see the Netconan help (`
       -w SENSITIVE_WORDS, --sensitive-words SENSITIVE_WORDS
                             List of comma separated keywords to anonymize
       --preserve-prefixes PRESERVE_PREFIXES
-                            List of comma separated IPv4 prefixes to preserve
-                            (skip anonymizing the specified prefixes, but host
-                            bits are still anonymized)
+                            List of comma separated IP prefixes to preserve.
+                            Specified prefixes are preserved, but the host bits
+                            within those prefixes are still anonymized. To
+                            preserve the entire network block, use --preserve-
+                            addresses instead
       --preserve-addresses PRESERVE_ADDRESSES
-                            List of comma separated IPv4 addresses or networks to
-                            preserve (skip anonymizing the specified addresses)
-      --preserve-private-addresses, --preserve-rfc-1918
-                            Preserve private-use IPv4 addresses (skip anonymizing
+                            List of comma separated IP addresses or networks to
+                            preserve
+      --preserve-private-addresses
+                            Preserve private-use IP addresses (skip anonymizing
                             addresses in 192.168.0.0/16, 172.16.0.0/12, and
                             10.0.0.0/8)

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -34,7 +34,7 @@ _CHAR_CHOICES = string.ascii_letters + string.digits
 def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
                     salt=None, dumpfile=None, sensitive_words=None,
                     undo_ip_anon=False, as_numbers=None, reserved_words=None,
-                    preserve_prefixes=None):
+                    preserve_prefixes=None, preserve_networks=None):
     """Anonymize each file in input and save to output."""
     anonymizer4 = None
     anonymizer6 = None
@@ -56,7 +56,7 @@ def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
     if sensitive_words is not None:
         anonymizer_sensitive_word = SensitiveWordAnonymizer(sensitive_words, salt)
     if anon_ip or undo_ip_anon:
-        anonymizer4 = IpAnonymizer(salt, preserve_prefixes)
+        anonymizer4 = IpAnonymizer(salt, preserve_prefixes, preserve_networks)
         anonymizer6 = IpV6Anonymizer(salt)
     if as_numbers is not None:
         anonymizer_as_num = AsNumberAnonymizer(as_numbers, salt)

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -168,7 +168,7 @@ class IpAnonymizer(_BaseIpAnonymizer):
         super(IpAnonymizer, self).__init__(salt, 32, **kwargs)
 
         if preserve_prefixes is None:
-            preserve_prefixes = self.DEFAULT_PRESERVED_PREFIXES
+            preserve_prefixes = list(self.DEFAULT_PRESERVED_PREFIXES)
 
         self._preserve_addresses = []
         if preserve_addresses is not None:
@@ -178,7 +178,7 @@ class IpAnonymizer(_BaseIpAnonymizer):
             ]
             # Make sure the prefixes are also preserved for preserved blocks, so
             # anonymized addresses outside the block don't accidentally collide
-            preserve_addresses.extend(preserve_addresses)
+            preserve_prefixes.extend(preserve_addresses)
 
         # Preserve relevant prefixes
         for subnet_str in preserve_prefixes:

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -167,7 +167,8 @@ class IpAnonymizer(_BaseIpAnonymizer):
         self._preserve_networks = []
         if preserve_networks is not None:
             self._preserve_networks = [
-                ipaddress.ip_network(n) for n in preserve_networks
+                ipaddress.ip_network(_ensure_unicode(n))
+                for n in preserve_networks
             ]
             # Make sure the prefixes are also preserved for preserved blocks, so
             # anonymized addresses outside the block don't accidentally collide

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -163,22 +163,22 @@ class IpAnonymizer(_BaseIpAnonymizer):
 
     _DROP_ZEROS_PATTERN = regex.compile(r'0*(\d+)\.0*(\d+)\.0*(\d+)\.0*(\d+)')
 
-    def __init__(self, salt, preserve_prefixes=None, preserve_networks=None, **kwargs):
+    def __init__(self, salt, preserve_prefixes=None, preserve_addresses=None, **kwargs):
         """Create an anonymizer using the specified salt."""
         super(IpAnonymizer, self).__init__(salt, 32, **kwargs)
 
         if preserve_prefixes is None:
             preserve_prefixes = self.DEFAULT_PRESERVED_PREFIXES
 
-        self._preserve_networks = []
-        if preserve_networks is not None:
-            self._preserve_networks = [
+        self._preserve_addresses = []
+        if preserve_addresses is not None:
+            self._preserve_addresses = [
                 ipaddress.ip_network(_ensure_unicode(n))
-                for n in preserve_networks
+                for n in preserve_addresses
             ]
             # Make sure the prefixes are also preserved for preserved blocks, so
             # anonymized addresses outside the block don't accidentally collide
-            preserve_networks.extend(preserve_networks)
+            preserve_addresses.extend(preserve_addresses)
 
         # Preserve relevant prefixes
         for subnet_str in preserve_prefixes:
@@ -230,7 +230,7 @@ class IpAnonymizer(_BaseIpAnonymizer):
         ip = ipaddress.ip_address(ip_int)
         return not (
             self._is_mask(ip_int) or
-            any([ip in n for n in self._preserve_networks])
+            any([ip in n for n in self._preserve_addresses])
         )
 
 

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -146,15 +146,21 @@ class _BaseIpAnonymizer(object):
 class IpAnonymizer(_BaseIpAnonymizer):
     """An anonymizer for IPv4 addresses."""
 
-    DEFAULT_PRESERVED_PREFIXES = (
-        '0.0.0.0/1',        # Class A
-        '128.0.0.0/2',      # Class B
-        '192.0.0.0/3',      # Class C
-        '224.0.0.0/4',      # Class D (implies class E)
-        '10.0.0.0/8',       # Private-use subnet
-        '172.16.0.0/12',    # Private-use subnet
-        '192.168.0.0/16',   # Private-use subnet
+    IPV4_CLASSES = (
+        '0.0.0.0/1',  # Class A
+        '128.0.0.0/2',  # Class B
+        '192.0.0.0/3',  # Class C
+        '224.0.0.0/4',  # Class D (implies class E)
     )
+
+    RFC_1918_NETWORKS = (
+        '10.0.0.0/8',  # Private-use subnet
+        '172.16.0.0/12',  # Private-use subnet
+        '192.168.0.0/16',  # Private-use subnet
+    )
+
+    DEFAULT_PRESERVED_PREFIXES = IPV4_CLASSES + RFC_1918_NETWORKS
+
     _DROP_ZEROS_PATTERN = regex.compile(r'0*(\d+)\.0*(\d+)\.0*(\d+)\.0*(\d+)')
 
     def __init__(self, salt, preserve_prefixes=None, preserve_networks=None, **kwargs):

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -147,15 +147,15 @@ class IpAnonymizer(_BaseIpAnonymizer):
     """An anonymizer for IPv4 addresses."""
 
     IPV4_CLASSES = (
-        '0.0.0.0/1',  # Class A
+        '0.0.0.0/1',    # Class A
         '128.0.0.0/2',  # Class B
         '192.0.0.0/3',  # Class C
         '224.0.0.0/4',  # Class D (implies class E)
     )
 
     RFC_1918_NETWORKS = (
-        '10.0.0.0/8',  # Private-use subnet
-        '172.16.0.0/12',  # Private-use subnet
+        '10.0.0.0/8',      # Private-use subnet
+        '172.16.0.0/12',   # Private-use subnet
         '192.168.0.0/16',  # Private-use subnet
     )
 

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -64,12 +64,12 @@ def _parse_args(argv):
                         help='List of comma separated keywords to anonymize')
     parser.add_argument('--preserve-prefixes',
                         default=','.join(IpAnonymizer.DEFAULT_PRESERVED_PREFIXES),
-                        help='List of comma separated IPv4 prefixes to preserve (do not anonymize the specified prefixes, but host bits are still anonymized)')
+                        help='List of comma separated IPv4 prefixes to preserve (skip anonymizing the specified prefixes, but host bits are still anonymized)')
     parser.add_argument('--preserve-networks', default=None,
-                        help='List of comma separated IPv4 networks to preserve (do not anonymize the prefix or host bits in the specified blocks)')
+                        help='List of comma separated IPv4 networks to preserve (skip anonymizing the prefix and host bits in the specified blocks)')
     parser.add_argument('--preserve-private-networks', '--preserve-rfc-1918',
                         action='store_true', default=False,
-                        help='Preserve private-use IPv4 networks (do not anonymize the prefix or host bits for addresses in 192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8)')
+                        help='Preserve private-use IPv4 networks (skip anonymizing the prefix or host bits for addresses in 192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8)')
     return parser.parse_args(argv)
 
 

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -65,11 +65,11 @@ def _parse_args(argv):
     parser.add_argument('--preserve-prefixes',
                         default=','.join(IpAnonymizer.DEFAULT_PRESERVED_PREFIXES),
                         help='List of comma separated IPv4 prefixes to preserve (skip anonymizing the specified prefixes, but host bits are still anonymized)')
-    parser.add_argument('--preserve-networks', default=None,
-                        help='List of comma separated IPv4 networks to preserve (skip anonymizing the prefix and host bits in the specified blocks)')
-    parser.add_argument('--preserve-private-networks', '--preserve-rfc-1918',
+    parser.add_argument('--preserve-addresses', default=None,
+                        help='List of comma separated IPv4 addresses or networks to preserve (skip anonymizing the prefix and host bits in the specified addresses)')
+    parser.add_argument('--preserve-private-addresses', '--preserve-rfc-1918',
                         action='store_true', default=False,
-                        help='Preserve private-use IPv4 networks (skip anonymizing the prefix or host bits for addresses in 192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8)')
+                        help='Preserve private-use IPv4 addresses (skip anonymizing addresses in 192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8)')
     return parser.parse_args(argv)
 
 
@@ -115,15 +115,15 @@ def main(argv=sys.argv[1:]):
     if args.preserve_prefixes is not None:
         preserve_prefixes = args.preserve_prefixes.split(',')
 
-    preserve_networks = None
-    if args.preserve_networks is not None:
-        preserve_networks = args.preserve_networks.split(',')
+    preserve_addresses = None
+    if args.preserve_addresses is not None:
+        preserve_addresses = args.preserve_addresses.split(',')
 
-    if args.preserve_private_networks:
-        private_networks = list(IpAnonymizer.RFC_1918_NETWORKS)
-        # Merge private networks with explicitly preserved networks
-        preserve_networks = private_networks if preserve_networks is None else (
-            preserve_networks + private_networks
+    if args.preserve_private_addresses:
+        addrs = list(IpAnonymizer.RFC_1918_NETWORKS)
+        # Merge private addresses with explicitly preserved addresses
+        preserve_addresses = addrs if preserve_addresses is None else (
+            preserve_addresses + addrs
         )
 
     if not any([
@@ -139,7 +139,7 @@ def main(argv=sys.argv[1:]):
         anonymize_files(args.input, args.output, args.anonymize_passwords,
                         args.anonymize_ips, args.salt, args.dump_ip_map,
                         sensitive_words, args.undo, as_numbers, reserved_words,
-                        preserve_prefixes, preserve_networks)
+                        preserve_prefixes, preserve_addresses)
 
 
 if __name__ == '__main__':

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -65,6 +65,8 @@ def _parse_args(argv):
     parser.add_argument('--preserve-prefixes',
                         default=','.join(IpAnonymizer.DEFAULT_PRESERVED_PREFIXES),
                         help='List of comma separated IPv4 prefixes to preserve')
+    parser.add_argument('--preserve-networks', default=None,
+                        help='List of comma separated IPv4 networks to preserve')
     return parser.parse_args(argv)
 
 
@@ -110,6 +112,10 @@ def main(argv=sys.argv[1:]):
     if args.preserve_prefixes is not None:
         preserve_prefixes = args.preserve_prefixes.split(',')
 
+    preserve_networks = None
+    if args.preserve_networks is not None:
+        preserve_networks = args.preserve_networks.split(',')
+
     if not any([
         as_numbers,
         sensitive_words,
@@ -123,7 +129,7 @@ def main(argv=sys.argv[1:]):
         anonymize_files(args.input, args.output, args.anonymize_passwords,
                         args.anonymize_ips, args.salt, args.dump_ip_map,
                         sensitive_words, args.undo, as_numbers, reserved_words,
-                        preserve_prefixes)
+                        preserve_prefixes, preserve_networks)
 
 
 if __name__ == '__main__':

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -66,7 +66,7 @@ def _parse_args(argv):
                         default=','.join(IpAnonymizer.DEFAULT_PRESERVED_PREFIXES),
                         help='List of comma separated IPv4 prefixes to preserve (skip anonymizing the specified prefixes, but host bits are still anonymized)')
     parser.add_argument('--preserve-addresses', default=None,
-                        help='List of comma separated IPv4 addresses or networks to preserve (skip anonymizing the prefix and host bits in the specified addresses)')
+                        help='List of comma separated IPv4 addresses or networks to preserve (skip anonymizing the specified addresses)')
     parser.add_argument('--preserve-private-addresses', '--preserve-rfc-1918',
                         action='store_true', default=False,
                         help='Preserve private-use IPv4 addresses (skip anonymizing addresses in 192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8)')

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -64,12 +64,12 @@ def _parse_args(argv):
                         help='List of comma separated keywords to anonymize')
     parser.add_argument('--preserve-prefixes',
                         default=','.join(IpAnonymizer.DEFAULT_PRESERVED_PREFIXES),
-                        help='List of comma separated IPv4 prefixes to preserve (skip anonymizing the specified prefixes, but host bits are still anonymized)')
+                        help='List of comma separated IP prefixes to preserve. Specified prefixes are preserved, but the host bits within those prefixes are still anonymized. To preserve the entire network block, use --preserve-addresses instead')
     parser.add_argument('--preserve-addresses', default=None,
-                        help='List of comma separated IPv4 addresses or networks to preserve (skip anonymizing the specified addresses)')
-    parser.add_argument('--preserve-private-addresses', '--preserve-rfc-1918',
+                        help='List of comma separated IP addresses or networks to preserve (skip anonymizing the specified addresses)')
+    parser.add_argument('--preserve-private-addresses',
                         action='store_true', default=False,
-                        help='Preserve private-use IPv4 addresses (skip anonymizing addresses in 192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8)')
+                        help='Preserve private-use IP addresses (skip anonymizing addresses in 192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8)')
     return parser.parse_args(argv)
 
 

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -64,12 +64,12 @@ def _parse_args(argv):
                         help='List of comma separated keywords to anonymize')
     parser.add_argument('--preserve-prefixes',
                         default=','.join(IpAnonymizer.DEFAULT_PRESERVED_PREFIXES),
-                        help='List of comma separated IP prefixes to preserve. Specified prefixes are preserved, but the host bits within those prefixes are still anonymized. To preserve the entire network block, use --preserve-addresses instead')
+                        help='List of comma separated IP prefixes to preserve. Specified prefixes are preserved, but the host bits within those prefixes are still anonymized. To preserve prefixes and host bits in specified blocks, use --preserve-addresses instead')
     parser.add_argument('--preserve-addresses', default=None,
-                        help='List of comma separated IP addresses or networks to preserve (skip anonymizing the specified addresses)')
+                        help='List of comma separated IP addresses or networks to preserve. Prefixes and host bits within those networks are preserved.  To preserve just prefixes and anonymize host bits, use --preserve-prefixes')
     parser.add_argument('--preserve-private-addresses',
                         action='store_true', default=False,
-                        help='Preserve private-use IP addresses (skip anonymizing addresses in 192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8)')
+                        help='Preserve private-use IP addresses. Prefixes and host bits within the private-use IP networks are preserved. To preserve specific addresses or networks, use --preserve-addresses instead. To preserve just prefixes and anonymize host bits, use --preserve-prefixes')
     return parser.parse_args(argv)
 
 

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -20,6 +20,7 @@ from netconan.netconan import main
 INPUT_CONTENTS = """
 # Intentionet's sensitive test file
 ip address 192.168.2.1 255.255.255.255
+ip address 111.111.111.111
 ip address 1.2.3.4 0.0.0.0
 my hash is $1$salt$ABCDEFGHIJKLMNOPQRS
 AS num 12345 and 65432 should be changed
@@ -33,6 +34,7 @@ ip address 11.11.197.79 0.0.0.0
 REF_CONTENTS = """
 # 1cbbc2's fd8607 test file
 ip address 192.168.2.13 255.255.255.255
+ip address 111.111.111.111
 ip address 77.86.28.249 0.0.0.0
 my hash is $1$0000$CxUUGIrqPb7GaB5midrQZ.
 AS num 8625 and 64818 should be changed
@@ -66,7 +68,7 @@ def test_end_to_end(tmpdir):
         '-r', 'reservedword',
         '-n', '65432,12345',
         '--preserve-networks', '11.11.0.0/16',
-        '--preserve-prefixes', '192.168.2.0/24',
+        '--preserve-addresses', '192.168.2.0/24,111.111.111.111',
     ]
     main(args)
 

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -66,7 +66,7 @@ def test_end_to_end(tmpdir):
         '-w', 'intentionet,sensitive',
         '-r', 'reservedword',
         '-n', '65432,12345',
-        '--preserve-networks', '11.11.0.0/16'
+        '--preserve-networks', '11.11.0.0/16',
     ]
     main(args)
 

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -26,6 +26,8 @@ my hash is $1$salt$ABCDEFGHIJKLMNOPQRS
 AS num 12345 and 65432 should be changed
 password foobar
 password reservedword
+ip address 11.11.11.11 0.0.0.0
+ip address 11.11.197.79 0.0.0.0
 
 """
 
@@ -37,6 +39,8 @@ my hash is $1$0000$CxUUGIrqPb7GaB5midrQZ.
 AS num 8625 and 64818 should be changed
 password netconanRemoved1
 password reservedword
+ip address 11.11.11.11 0.0.0.0
+ip address 11.11.197.79 0.0.0.0
 
 """
 
@@ -62,6 +66,7 @@ def test_end_to_end(tmpdir):
         '-w', 'intentionet,sensitive',
         '-r', 'reservedword',
         '-n', '65432,12345',
+        '--preserve-networks', '11.11.0.0/16'
     ]
     main(args)
 

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -67,8 +67,8 @@ def test_end_to_end(tmpdir):
         '-w', 'intentionet,sensitive',
         '-r', 'reservedword',
         '-n', '65432,12345',
-        '--preserve-networks', '11.11.0.0/16',
-        '--preserve-addresses', '192.168.2.0/24,111.111.111.111',
+        '--preserve-addresses', '11.11.0.0/16,111.111.111.111',
+        '--preserve-prefixes', '192.168.2.0/24',
     ]
     main(args)
 

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -35,7 +35,7 @@ REF_CONTENTS = """
 # 1cbbc2's fd8607 test file
 ip address 192.168.2.13 255.255.255.255
 ip address 111.111.111.111
-ip address 77.86.28.249 0.0.0.0
+ip address 5.86.28.249 0.0.0.0
 my hash is $1$0000$CxUUGIrqPb7GaB5midrQZ.
 AS num 8625 and 64818 should be changed
 password netconanRemoved1

--- a/tests/unit/test_ip_anonymization.py
+++ b/tests/unit/test_ip_anonymization.py
@@ -235,6 +235,22 @@ def test_preserve_custom_prefixes():
     assert (ipaddress.ip_address(ip_end_anon) in network)
 
 
+def test_preserve_custom_networks():
+    """Test that addresses within a preserved network are flagged correctly as NOT needing anonymization."""
+    network = '170.0.0.0/8'
+    anonymizer = IpAnonymizer(SALT, preserve_networks=[network])
+
+    ip_start = int(anonymizer.make_addr('170.0.0.0'))
+    ip_end = int(anonymizer.make_addr('170.255.255.255'))
+    ip_other = int(anonymizer.make_addr('10.11.12.13'))
+
+    # Make sure anonymizer indicates addresses within preserved network block should not be anonymized
+    assert not anonymizer.should_anonymize(ip_start)
+    assert not anonymizer.should_anonymize(ip_end)
+    # Make sure the address outside the preserved block should be anonymized
+    assert anonymizer.should_anonymize(ip_other)
+
+
 @pytest.mark.parametrize('start, end, subnet', private_blocks)
 def test_preserve_private_prefixes(anonymizer_v4, start, end, subnet):
     """Test that private-use prefixes are preserved by default."""

--- a/tests/unit/test_ip_anonymization.py
+++ b/tests/unit/test_ip_anonymization.py
@@ -235,20 +235,26 @@ def test_preserve_custom_prefixes():
     assert (ipaddress.ip_address(ip_end_anon) in network)
 
 
-def test_preserve_custom_networks():
-    """Test that addresses within a preserved network are flagged correctly as NOT needing anonymization."""
-    network = '170.0.0.0/8'
-    anonymizer = IpAnonymizer(SALT, preserve_networks=[network])
+def test_preserve_custom_addresses():
+    """Test that addresses within a preserved block are flagged correctly as NOT needing anonymization."""
+    addresses = [
+        '170.0.0.0/8',
+        '11.11.11.11',
+    ]
+    anonymizer = IpAnonymizer(SALT, preserve_addresses=addresses)
 
     ip_start = int(anonymizer.make_addr('170.0.0.0'))
     ip_end = int(anonymizer.make_addr('170.255.255.255'))
-    ip_other = int(anonymizer.make_addr('10.11.12.13'))
+    ip_other = int(anonymizer.make_addr('11.11.11.11'))
+    ip_outside = int(anonymizer.make_addr('10.11.12.13'))
 
-    # Make sure anonymizer indicates addresses within preserved network block should not be anonymized
+    # Make sure anonymizer indicates addresses within preserved network blocks should not be anonymized
     assert not anonymizer.should_anonymize(ip_start)
     assert not anonymizer.should_anonymize(ip_end)
+    assert not anonymizer.should_anonymize(ip_other)
+
     # Make sure the address outside the preserved block should be anonymized
-    assert anonymizer.should_anonymize(ip_other)
+    assert anonymizer.should_anonymize(ip_outside)
 
 
 @pytest.mark.parametrize('start, end, subnet', private_blocks)

--- a/tests/unit/test_ip_anonymization.py
+++ b/tests/unit/test_ip_anonymization.py
@@ -285,9 +285,7 @@ def _cpl_v4(left, right):
     _cpl_v4(1.0.0.1, 1.0.128.1) == 16
     _cpl_v4(1.0.0.1, 128.0.0.1) == 0
     """
-    l = int(left)
-    r = int(right)
-    xor = l ^ r
+    xor = int(left) ^ int(right)
     max_shift = 32
     for i in reversed(range(max_shift)):
         if xor & (0x1 << i):


### PR DESCRIPTION
Add option to preserve specified network block(s).

For example, if a user wants to anonymize IPv4 addresses but preserve private-use addresses, they could run:
```
netconan -a -i input_dir/ -o output_dir/ --preserve-private-addresses
```

Or to preserve specific, non-private addresses, user could run something like:
```
netconan -a -i input_dir/ -o output_dir/ --preserve-addresses 11.12.13.14,111.111.0.0/16
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/129)
<!-- Reviewable:end -->
