### PR TITLE
Ensure unicode for user-specified preserved-prefixes

### DIFF
--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -166,7 +166,7 @@ class IpAnonymizer(_BaseIpAnonymizer):
 
         # Preserve relevant prefixes
         for subnet_str in preserve_prefixes:
-            subnet = ipaddress.ip_network(subnet_str)
+            subnet = ipaddress.ip_network(_ensure_unicode(subnet_str))
             prefix_bits = self.fmt.format(int(subnet.network_address))[:subnet.prefixlen]
             for position in range(len(prefix_bits)):
                 value = prefix_bits[:position]

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -31,7 +31,7 @@ password reservedword
 
 REF_CONTENTS = """
 # 1cbbc2's fd8607 test file
-ip address 192.168.139.13 255.255.255.255
+ip address 192.168.2.13 255.255.255.255
 ip address 5.86.28.249 0.0.0.0
 my hash is $1$0000$CxUUGIrqPb7GaB5midrQZ.
 AS num 8625 and 64818 should be changed
@@ -62,6 +62,7 @@ def test_end_to_end(tmpdir):
         '-w', 'intentionet,sensitive',
         '-r', 'reservedword',
         '-n', '65432,12345',
+        '--preserve-prefixes', '192.168.2.0/24',
     ]
     main(args)
 

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -65,7 +65,7 @@ def test_end_to_end(tmpdir):
     ]
     main(args)
 
-    with open(ref_file) as f_ref, open(output_file) as f_out:
+    with open(str(ref_file)) as f_ref, open(str(output_file)) as f_out:
         t_ref = f_ref.read().split('\n')
         t_out = f_out.read().split('\n')
 

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -66,6 +66,7 @@ def test_end_to_end(tmpdir):
     main(args)
 
     with open(str(ref_file)) as f_ref, open(str(output_file)) as f_out:
+        # Compare lines for more readable failed assertion message
         t_ref = f_ref.read().split('\n')
         t_out = f_out.read().split('\n')
 

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -13,7 +13,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import filecmp
 import os.path
 
 from netconan.netconan import main
@@ -32,7 +31,7 @@ password reservedword
 REF_CONTENTS = """
 # 1cbbc2's fd8607 test file
 ip address 192.168.2.13 255.255.255.255
-ip address 5.86.28.249 0.0.0.0
+ip address 77.86.28.249 0.0.0.0
 my hash is $1$0000$CxUUGIrqPb7GaB5midrQZ.
 AS num 8625 and 64818 should be changed
 password netconanRemoved1
@@ -66,8 +65,12 @@ def test_end_to_end(tmpdir):
     ]
     main(args)
 
-    # Make sure output file matches the ref
-    assert(filecmp.cmp(str(ref_file), str(output_file)))
+    with open(ref_file) as f_ref, open(output_file) as f_out:
+        t_ref = f_ref.read().split('\n')
+        t_out = f_out.read().split('\n')
+
+    # Make sure output file lines match ref lines
+    assert t_ref == t_out
 
 
 def test_end_to_end_no_anonymization(tmpdir):


### PR DESCRIPTION
Fixes a bug where `Netconan` would crash when preserved prefixes were specified in Python2:
`AddressValueError: <prefix> does not appear to be an IPv4 or IPv6 network. Did you pass in a bytes (str in Python 2) instead of a unicode object?`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/130)
<!-- Reviewable:end -->
