### PR TITLE
Use `re` in place of `regex`

### DIFF
--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -28,6 +28,7 @@ from six import add_metaclass, iteritems, text_type, u
 _IPv4_OCTET_PATTERN = r'(25[0-5]|(2[0-4]|1?[0-9])?[0-9])'
 
 # Deliberately allowing leading zeros and will remove them later
+# Match address starting at beginning of line or surrounded by appropriate enclosing chars
 IPv4_PATTERN = re.compile(
     r'(?:(?<=^)|(?<=[\s:<>/\'",=\(]))'
     r'((0*{octet}\.){{3}}0*{octet})'

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -19,7 +19,6 @@ from abc import ABCMeta, abstractmethod
 from bidict import bidict
 import ipaddress
 import logging
-# Need regex instead of re for variable look behind
 import re
 
 from hashlib import md5

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -291,4 +291,4 @@ def anonymize_ip_addr(anonymizer, line, undo_ip_anon=False):
     will be replaced with the unanonymized address.
     """
     pattern = anonymizer.get_addr_pattern()
-    return pattern.sub(lambda match: _anonymize_match(anonymizer, match[0], undo_ip_anon), line)
+    return pattern.sub(lambda match: _anonymize_match(anonymizer, match.group(0), undo_ip_anon), line)

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -20,7 +20,7 @@ from bidict import bidict
 import ipaddress
 import logging
 # Need regex instead of re for variable look behind
-import regex
+import re
 
 from hashlib import md5
 from six import add_metaclass, iteritems, text_type, u
@@ -29,13 +29,15 @@ from six import add_metaclass, iteritems, text_type, u
 _IPv4_OCTET_PATTERN = r'(25[0-5]|(2[0-4]|1?[0-9])?[0-9])'
 
 # Deliberately allowing leading zeros and will remove them later
-IPv4_PATTERN = regex.compile(
-    r'(?<=^|[\s:<>/\'",=\(])((0*{octet}\.){{3}}0*{octet})'
+IPv4_PATTERN = re.compile(
+    r'(?:(?<=^)|(?<=[\s:<>/\'",=\(]))'
+    r'((0*{octet}\.){{3}}0*{octet})'
     r'(?=/(\d{{1,3}}))?(?=[-\s:<>/\'",=\]\)]|$)'.format(octet=_IPv4_OCTET_PATTERN))
 
 # Modified from https://stackoverflow.com/a/17871737/1715495
-IPv6_PATTERN = regex.compile(
-    r'(?<=^|[\s<>/\'",=\(])(([0-9a-f]{1,4}:){7,7}[0-9a-f]{1,4}'
+IPv6_PATTERN = re.compile(
+    r'(?:(?<=^)|(?<=[\s<>/\'",=\(]))'
+    r'(([0-9a-f]{1,4}:){7,7}[0-9a-f]{1,4}'
     r'|([0-9a-f]{1,4}:){1,7}:'
     r'|([0-9a-f]{1,4}:){1,6}:[0-9a-f]{1,4}'
     r'|([0-9a-f]{1,4}:){1,5}(:[0-9a-f]{1,4}){1,2}'
@@ -49,7 +51,7 @@ IPv6_PATTERN = regex.compile(
     r'|([0-9a-f]{{1,4}}:){{1,4}}:({octet}\.){{3}}{octet})'.format(
         octet=_IPv4_OCTET_PATTERN) +
     r'(?=[-\s<>/\'",=\]\)]|$)',
-    regex.IGNORECASE)
+    re.IGNORECASE)
 
 
 def _generate_bit_from_hash(salt, string):
@@ -161,7 +163,7 @@ class IpAnonymizer(_BaseIpAnonymizer):
 
     DEFAULT_PRESERVED_PREFIXES = IPV4_CLASSES + RFC_1918_NETWORKS
 
-    _DROP_ZEROS_PATTERN = regex.compile(r'0*(\d+)\.0*(\d+)\.0*(\d+)\.0*(\d+)')
+    _DROP_ZEROS_PATTERN = re.compile(r'0*(\d+)\.0*(\d+)\.0*(\d+)\.0*(\d+)')
 
     def __init__(self, salt, preserve_prefixes=None, preserve_addresses=None, **kwargs):
         """Create an anonymizer using the specified salt."""

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -33,7 +33,7 @@ from six import b
 # regex (e.g. sensitive line is allowed to be in quotes or after a colon)
 # This is an ignored group, so it does not muck with the password regex indicies
 # And the ?<= is a lookbehind, not part of regex match text/sub text
-_ALLOWED_REGEX_PREFIX = r'(?:(?<=[^-_a-zA-Z\d])|(?<=^)|(?<= ))'
+_ALLOWED_REGEX_PREFIX = r'(?:(?<=[^-_a-zA-Z\d])|(?<=[^-_a-zA-Z\d] )|(?<=^)|(?<=^ ))'
 
 # Number of digits to extract from hash for sensitive keyword replacement
 _ANON_SENSITIVE_WORD_LEN = 6

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -31,8 +31,8 @@ from six import b
 # A regex matching any of the characters that are allowed to precede a password
 # regex (e.g. sensitive line is allowed to be in quotes or after a colon)
 # This is an ignored group, so it does not muck with the password regex indicies
-# And the \K means it is not part of the regex match text/sub text
-_ALLOWED_REGEX_PREFIX = r'(?:[^-_a-zA-Z\d] ?|^ ?)\K'
+# And the ?<= means it is a look-around, not part of regex match text/sub text
+_ALLOWED_REGEX_PREFIX = r'(?:(?<=[^-_a-zA-Z\d])|(?<=^)|(?<= ))'
 
 # Number of digits to extract from hash for sensitive keyword replacement
 _ANON_SENSITIVE_WORD_LEN = 6

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -32,7 +32,7 @@ from six import b
 # A regex matching any of the characters that are allowed to precede a password
 # regex (e.g. sensitive line is allowed to be in quotes or after a colon)
 # This is an ignored group, so it does not muck with the password regex indicies
-# And the ?<= means it is a look-around, not part of regex match text/sub text
+# And the ?<= is a lookbehind, not part of regex match text/sub text
 _ALLOWED_REGEX_PREFIX = r'(?:(?<=[^-_a-zA-Z\d])|(?<=^)|(?<= ))'
 
 # Number of digits to extract from hash for sensitive keyword replacement
@@ -163,7 +163,7 @@ class SensitiveWordAnonymizer(object):
     @classmethod
     def _generate_sensitive_word_regex(cls, sensitive_words):
         """Compile and return regex for the specified list of sensitive words."""
-        return regex.compile('({})'.format('|'.join(sensitive_words)), regex.IGNORECASE)
+        return re.compile('({})'.format('|'.join(sensitive_words)), regex.IGNORECASE)
 
     @classmethod
     def _generate_sensitive_word_replacements(cls, sensitive_words, salt):
@@ -276,17 +276,17 @@ def _check_sensitive_item_format(val):
 
     # Order is important here (e.g. type 7 looks like hex or text, but has a
     # specific format so it should override hex or text)
-    if regex.match(r'^\$9\$[\S]+$', val):
+    if re.match(r'^\$9\$[\S]+$', val):
         item_format = _sensitive_item_formats.juniper_type9
-    if regex.match(r'^\$6\$[\S]+$', val):
+    if re.match(r'^\$6\$[\S]+$', val):
         item_format = _sensitive_item_formats.sha512
-    if regex.match(r'^\$1\$[\S]+\$[\S]+$', val):
+    if re.match(r'^\$1\$[\S]+\$[\S]+$', val):
         item_format = _sensitive_item_formats.md5
-    if regex.match(r'^[0-9a-fA-F]+$', val):
+    if re.match(r'^[0-9a-fA-F]+$', val):
         item_format = _sensitive_item_formats.hexadecimal
-    if regex.match(r'^[01][0-9]([0-9a-fA-F]{2})+$', val):
+    if re.match(r'^[01][0-9]([0-9a-fA-F]{2})+$', val):
         item_format = _sensitive_item_formats.cisco_type7
-    if regex.match(r'^[0-9]+$', val):
+    if re.match(r'^[0-9]+$', val):
         item_format = _sensitive_item_formats.numeric
     return item_format
 

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 # Need regex here instead of re for variable length lookbehinds
 import regex
+import re
 import logging
 
 from binascii import b2a_hex
@@ -65,18 +66,18 @@ _PASSWORD_ENCLOSING_TAIL_TEXT = _PASSWORD_ENCLOSING_TEXT + [']', '}', ';', ',']
 # These are extra regexes to find lines that seem like they might contain
 # sensitive info (these are not already caught by RANCID default regexes)
 extra_password_regexes = [
-    [(r'encrypted-password \K(\S+)', None)],
-    [(r'key "\K([^"]+)', 1)],
-    [(r'key-hash sha256 \K(\S+)', 1)],
+    [(r'(?<=encrypted-password )(\S+)', None)],
+    [(r'(?<=key ")([^"]+)', 1)],
+    [(r'(?<=key-hash sha256 )(\S+)', 1)],
     # Replace communities that do not look like well-known BGP communities
     # i.e. snmp communities
-    [(r'set community \K((?!{ignore})\S+)'
+    [(r'(?<=set community )((?!{ignore})\S+)'
       .format(ignore=_IGNORED_COMMUNITIES), 1)],
-    [(r'snmp-server mib community-map \K([^ :]+)', 1)],
-    [(r'snmp-community \K(\S+)', 1)],
+    [(r'(?<=snmp-server mib community-map )([^ :]+)', 1)],
+    [(r'(?<=snmp-community )(\S+)', 1)],
     # Catch-all's matching what looks like hashed passwords
-    [(r'\K("?\$9\$[^\s;"]+)', 1)],
-    [(r'\K("?\$1\$[^\s;"]+)', 1)],
+    [(r'("?\$9\$[^\s;"]+)', 1)],
+    [(r'("?\$1\$[^\s;"]+)', 1)],
 ]
 
 
@@ -101,7 +102,7 @@ class AsNumberAnonymizer(object):
         """Generate regex for finding AS number."""
         # Match a non-digit, any of the AS numbers and another non-digit
         # Using lookahead and lookbehind to match on context but not include that context in the match
-        self.as_num_regex = regex.compile(r'(\D|^)\K({})(?=\D|$)'.format(
+        self.as_num_regex = re.compile(r'(?:(?<=\D)|(?<=^))({})(?=\D|$)'.format(
             '|'.join(as_numbers)))
 
     def _generate_as_number_replacement(self, as_number):

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -33,7 +33,8 @@ from six import b
 # regex (e.g. sensitive line is allowed to be in quotes or after a colon)
 # This is an ignored group, so it does not muck with the password regex indicies
 # And the ?<= is a lookbehind, not part of regex match text/sub text
-_ALLOWED_REGEX_PREFIX = r'(?:(?<=[^-_a-zA-Z\d])|(?<=[^-_a-zA-Z\d] )|(?<=^)|(?<=^ ))'
+_ALLOWED_REGEX_PREFIX = (r'(?:(?<={prefix})|(?<={prefix} )|(?<=^)|(?<=^ ))'
+                         .format(prefix=r'[^-_a-zA-Z\d]'))
 
 # Number of digits to extract from hash for sensitive keyword replacement
 _ANON_SENSITIVE_WORD_LEN = 6

--- a/tests/unit/test_ip_anonymization.py
+++ b/tests/unit/test_ip_anonymization.py
@@ -16,7 +16,7 @@
 from __future__ import unicode_literals
 import ipaddress
 import pytest
-import regex
+import re
 
 from netconan.ip_anonymization import (
     IpAnonymizer, IpV6Anonymizer, anonymize_ip_addr, _ensure_unicode)
@@ -399,7 +399,7 @@ def test_dump_iptree(tmpdir, anonymizer_v4):
     with open(filename, 'r') as f_tmp:
         # Build mapping dict from the output of the ip_tree dump
         for line in f_tmp.readlines():
-            m = regex.match(r'\s*(\d+\.\d+.\d+.\d+)\s+(\d+\.\d+.\d+.\d+)\s*', line)
+            m = re.match(r'\s*(\d+\.\d+.\d+.\d+)\s+(\d+\.\d+.\d+.\d+)\s*', line)
             ip_addr = m.group(1)
             ip_addr_anon = m.group(2)
             ip_mapping_from_dump[ip_addr] = ip_addr_anon


### PR DESCRIPTION
Use Python built-in `re` in place of `regex` in several places.  This mostly involves replacing variable-length lookbehinds (not supported by `re`) with combinations of fixed-length lookbehinds.

Sensitive line anonymization (i.e. password regexes) will require more/alternative work due to extensive use of non-trivial variable-length lookbehinds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/132)
<!-- Reviewable:end -->
