### PR TITLE
Fix CI install

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -2,6 +2,8 @@
 set -x -e
 
 if [ -n "$TRAVIS_BUILD_DIR" ]; then
+   # Upgrade pip
+   pip install -U pip
    # Build and install netconan
    pip install -e .[dev]
 fi

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,9 @@ setup(
         'pytest>=4.2.0,<5.0.0',
         'pytest-cov<3.0.0',
         'requests_mock<2.0.0',
-        'testfixtures<7.0.0'
+        'testfixtures<7.0.0',
+        # zipp 2.2 does not work w/ Python 3.5
+        'zipp<2.2; python_version < "3.6"',
     ],
 
     # If there are data files included in your packages that need to be

--- a/setup.py
+++ b/setup.py
@@ -94,8 +94,8 @@ setup(
         'pytest-cov<3.0.0',
         'requests_mock<2.0.0',
         'testfixtures<7.0.0',
-        # zipp 2.2 does not work w/ Python 3.5
-        'zipp<2.2; python_version < "3.6"',
+        # zipp 2.2 does not work w/ Python < 3.6
+        'zipp<2.2',
     ],
 
     # If there are data files included in your packages that need to be


### PR DESCRIPTION
`zipp` 2.2 does not work with Python 3.5, so install 2.1 for Python 3.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/136)
<!-- Reviewable:end -->
