### PR TITLE
Add option to remove "comments" from configs #134

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.7
   - 3.5
   - 3.6
+  - 3.7
 
 script: ./.travis/build.sh
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - 2.7
   - 3.5
   - 3.6
-  - 3.7
 
 script: ./.travis/build.sh
 cache: pip

--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,8 @@ For more information about less commonly-used features, see the Netconan help (`
                             List of comma separated keywords to anonymize
       --remove-lines REMOVE_LINES
                             List of comma separated words which should trigger
-                            removing a line entirely
+                            removing a line entirely. The line will be removed 
+							even if it contains a reserved word
       --preserve-prefixes PRESERVE_PREFIXES
                             List of comma separated IP prefixes to preserve.
                             Specified prefixes are preserved, but the host bits

--- a/README.rst
+++ b/README.rst
@@ -132,8 +132,9 @@ For more information about less commonly-used features, see the Netconan help (`
       -u, --undo            Undo reversible anonymization (must specify salt)
       -w SENSITIVE_WORDS, --sensitive-words SENSITIVE_WORDS
                             List of comma separated keywords to anonymize
-      -k KEYWORD_REMOVER, --keyword-remover KEYWORD_REMOVER
-                            List of comma seperated keywords to remove line
+      --remove-lines REMOVE_LINES
+                            List of comma separated words which should trigger
+                            removing a line entirely
       --preserve-prefixes PRESERVE_PREFIXES
                             List of comma separated IP prefixes to preserve.
                             Specified prefixes are preserved, but the host bits

--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,8 @@ For more information about less commonly-used features, see the Netconan help (`
       -u, --undo            Undo reversible anonymization (must specify salt)
       -w SENSITIVE_WORDS, --sensitive-words SENSITIVE_WORDS
                             List of comma separated keywords to anonymize
+      -k KEYWORD_REMOVER, --keyword-remover KEYWORD_REMOVER
+                            List of comma seperated keywords to remove line
       --preserve-prefixes PRESERVE_PREFIXES
                             List of comma separated IP prefixes to preserve.
                             Specified prefixes are preserved, but the host bits

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -25,7 +25,7 @@ from .ip_anonymization import (
     IpAnonymizer, IpV6Anonymizer, anonymize_ip_addr)
 from .sensitive_item_removal import (
     anonymize_as_numbers, AsNumberAnonymizer, replace_matching_item,
-    SensitiveWordAnonymizer, generate_default_sensitive_item_regexes)
+    SensitiveWordAnonymizer, generate_default_sensitive_item_regexes, LineRemover)
 
 _DEFAULT_SALT_LENGTH = 16
 _CHAR_CHOICES = string.ascii_letters + string.digits
@@ -34,7 +34,7 @@ _CHAR_CHOICES = string.ascii_letters + string.digits
 def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
                     salt=None, dumpfile=None, sensitive_words=None,
                     undo_ip_anon=False, as_numbers=None, reserved_words=None,
-                    preserve_prefixes=None, preserve_networks=None):
+                    preserve_prefixes=None, preserve_networks=None, keywords=None):
     """Anonymize each file in input and save to output."""
     anonymizer4 = None
     anonymizer6 = None
@@ -42,6 +42,7 @@ def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
     anonymizer_sensitive_word = None
     compiled_regexes = None
     pwd_lookup = None
+    line_remover = None
     # The salt is only used for IP and sensitive word anonymization:
     if salt is None:
         salt = ''.join(random.choice(_CHAR_CHOICES) for _ in range(_DEFAULT_SALT_LENGTH))
@@ -60,6 +61,8 @@ def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
         anonymizer6 = IpV6Anonymizer(salt)
     if as_numbers is not None:
         anonymizer_as_num = AsNumberAnonymizer(as_numbers, salt)
+    if keywords is not None:
+        line_remover = LineRemover(keywords)
 
     if not os.path.exists(input_path):
         raise ValueError("Input does not exist")
@@ -92,7 +95,8 @@ def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
                            anonymizer_as_num=anonymizer_as_num,
                            undo_ip_anon=undo_ip_anon,
                            anonymizer4=anonymizer4,
-                           anonymizer6=anonymizer6)
+                           anonymizer6=anonymizer6,
+                           line_remover=line_remover)
         except Exception:
             logging.error('Failed to anonymize file %s', in_path, exc_info=True)
 
@@ -105,7 +109,7 @@ def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
 def anonymize_file(filename_in, filename_out, compiled_regexes=None,
                    anonymizer4=None, anonymizer6=None, pwd_lookup=None,
                    anonymizer_sensitive_word=None, anonymizer_as_num=None,
-                   undo_ip_anon=False):
+                   undo_ip_anon=False, line_remover=None):
     """Anonymize contents of input file and save to the output file.
 
     This only applies sensitive line removal if compiled_regexes and pwd_lookup
@@ -125,6 +129,7 @@ def anonymize_file(filename_in, filename_out, compiled_regexes=None,
     with open(filename_out, 'w') as f_out, open(filename_in, 'r') as f_in:
         for line in f_in:
             output_line = line
+            remove_l = False
             if compiled_regexes is not None and pwd_lookup is not None:
                 output_line = replace_matching_item(compiled_regexes,
                                                     output_line, pwd_lookup)
@@ -140,10 +145,17 @@ def anonymize_file(filename_in, filename_out, compiled_regexes=None,
             if anonymizer_as_num is not None:
                 output_line = anonymize_as_numbers(anonymizer_as_num, output_line)
 
+            if line_remover is not None:
+                line_remover.remove = False
+                output_line = line_remover.remove_line(output_line)
+                remove_l = line_remover.get_remove()
+
             if line != output_line:
                 logging.debug("Input line:  %s", line.rstrip())
                 logging.debug("Output line: %s", output_line.rstrip())
-            f_out.write(output_line)
+
+            if (remove_l is False):
+                f_out.write(output_line)
 
 
 def _mkdirs(file_path):

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -129,7 +129,6 @@ def anonymize_file(filename_in, filename_out, compiled_regexes=None,
     with open(filename_out, 'w') as f_out, open(filename_in, 'r') as f_in:
         for line in f_in:
             output_line = line
-            remove_l = False
             if compiled_regexes is not None and pwd_lookup is not None:
                 output_line = replace_matching_item(compiled_regexes,
                                                     output_line, pwd_lookup)
@@ -146,16 +145,13 @@ def anonymize_file(filename_in, filename_out, compiled_regexes=None,
                 output_line = anonymize_as_numbers(anonymizer_as_num, output_line)
 
             if line_remover is not None:
-                line_remover.remove = False
                 output_line = line_remover.remove_line(output_line)
-                remove_l = line_remover.get_remove()
 
             if line != output_line:
                 logging.debug("Input line:  %s", line.rstrip())
                 logging.debug("Output line: %s", output_line.rstrip())
 
-            if (remove_l is False):
-                f_out.write(output_line)
+            f_out.write(output_line)
 
 
 def _mkdirs(file_path):

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -63,6 +63,7 @@ def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
         anonymizer_as_num = AsNumberAnonymizer(as_numbers, salt)
     if keywords is not None:
         line_remover = LineRemover(keywords)
+        logging.warning('The line will be removed even if it contains a reserved word')
 
     if not os.path.exists(input_path):
         raise ValueError("Input does not exist")

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -70,8 +70,8 @@ def _parse_args(argv):
     parser.add_argument('--preserve-private-addresses',
                         action='store_true', default=False,
                         help='Preserve private-use IP addresses. Prefixes and host bits within the private-use IP networks are preserved. To preserve specific addresses or networks, use --preserve-addresses instead. To preserve just prefixes and anonymize host bits, use --preserve-prefixes')
-    parser.add_argument('-k', '--keyword-remover', default=None,
-                        help='List of comma seperated keywords to remove.')
+    parser.add_argument('--remove-lines', default=None,
+                        help='List of comma separated words which should trigger removing a line entirely.')
     return parser.parse_args(argv)
 
 
@@ -129,8 +129,8 @@ def main(argv=sys.argv[1:]):
         )
 
     keywords = None
-    if args.keyword_remover is not None:
-        keywords = args.keyword_remover.split(',')
+    if args.remove_lines is not None:
+        keywords = args.remove_lines.split(',')
 
     if not any([
         as_numbers,

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -70,6 +70,8 @@ def _parse_args(argv):
     parser.add_argument('--preserve-private-addresses',
                         action='store_true', default=False,
                         help='Preserve private-use IP addresses. Prefixes and host bits within the private-use IP networks are preserved. To preserve specific addresses or networks, use --preserve-addresses instead. To preserve just prefixes and anonymize host bits, use --preserve-prefixes')
+    parser.add_argument('-k', '--keyword-remover', default=None,
+                        help='List of comma seperated keywords to remove.')
     return parser.parse_args(argv)
 
 
@@ -126,12 +128,17 @@ def main(argv=sys.argv[1:]):
             preserve_addresses + addrs
         )
 
+    keywords = None
+    if args.keyword_remover is not None:
+        keywords = args.keyword_remover.split(',')
+
     if not any([
         as_numbers,
         sensitive_words,
         args.anonymize_passwords,
         args.anonymize_ips,
-        args.undo
+        args.undo,
+        keywords
     ]):
         logging.warning('No anonymization options turned on, '
                         'no output file(s) will be generated.')
@@ -139,7 +146,7 @@ def main(argv=sys.argv[1:]):
         anonymize_files(args.input, args.output, args.anonymize_passwords,
                         args.anonymize_ips, args.salt, args.dump_ip_map,
                         sensitive_words, args.undo, as_numbers, reserved_words,
-                        preserve_prefixes, preserve_addresses)
+                        preserve_prefixes, preserve_addresses, keywords)
 
 
 if __name__ == '__main__':

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -182,18 +182,13 @@ class SensitiveWordAnonymizer(object):
 class LineRemover(object):
     """A line remover for interface descriptions, BGP neighbor descriptions, remarks in ACLs etc."""
 
-    def __init__(self, keywords, reserved_words=default_reserved_words, remove=False):
+    def __init__(self, keywords, reserved_words=default_reserved_words):
         """Create an anonymizer for specified list of sensitive words and set of reserved words to leave alone."""
         self.reserved_words = reserved_words
         self.keywords = keywords
         # Figure out which reserved words may clash with the keywords, so they can be preserved in removing
         self.conflicting_words = self._generate_conflicting_reserved_word_list(keywords)
         self.line_regex = self._generate_keyword_regex(keywords)
-        self.remove = remove
-
-    def get_remove(self):
-        """Return remove value."""
-        return self.remove
 
     def _generate_conflicting_reserved_word_list(self, keywords):
         """Return a set of keywords that may conflict with the specified default reserved words."""
@@ -217,8 +212,7 @@ class LineRemover(object):
             if w in self.reserved_words:
                 return line
         if (self.line_regex.search(line) is not None):
-            self.remove = True
-            return 'remove line'
+            return ''
         else:
             return line
 

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -182,23 +182,11 @@ class SensitiveWordAnonymizer(object):
 class LineRemover(object):
     """A line remover for interface descriptions, BGP neighbor descriptions, remarks in ACLs etc."""
 
-    def __init__(self, keywords, reserved_words=default_reserved_words):
+    def __init__(self, keywords):
         """Create an anonymizer for specified list of sensitive words and set of reserved words to leave alone."""
-        self.reserved_words = reserved_words
         self.keywords = keywords
         # Figure out which reserved words may clash with the keywords, so they can be preserved in removing
-        self.conflicting_words = self._generate_conflicting_reserved_word_list(keywords)
         self.line_regex = self._generate_keyword_regex(keywords)
-
-    def _generate_conflicting_reserved_word_list(self, keywords):
-        """Return a set of keywords that may conflict with the specified default reserved words."""
-        conflicting_words = set()
-        for keyword in keywords:
-            conflicting_words.update(set([w for w in self.reserved_words if keyword in w]))
-        if conflicting_words:
-            logging.warning('Specified keywords overlap with reserved words. '
-                            'The following reserved words will be preserved: %s', conflicting_words)
-        return conflicting_words
 
     @classmethod
     def _generate_keyword_regex(self, keywords):
@@ -207,10 +195,6 @@ class LineRemover(object):
 
     def remove_line(self, line):
         """Remove the input line."""
-        leading, words, trailing = _split_line(line)
-        for w in words:
-            if w in self.reserved_words:
-                return line
         if (self.line_regex.search(line) is not None):
             return ''
         else:

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -179,6 +179,50 @@ class SensitiveWordAnonymizer(object):
         return self.sens_word_replacements[match.group(0).lower()]
 
 
+class LineRemover(object):
+    """A line remover for interface descriptions, BGP neighbor descriptions, remarks in ACLs etc."""
+
+    def __init__(self, keywords, reserved_words=default_reserved_words, remove=False):
+        """Create an anonymizer for specified list of sensitive words and set of reserved words to leave alone."""
+        self.reserved_words = reserved_words
+        self.keywords = keywords
+        # Figure out which reserved words may clash with the keywords, so they can be preserved in removing
+        self.conflicting_words = self._generate_conflicting_reserved_word_list(keywords)
+        self.line_regex = self._generate_keyword_regex(keywords)
+        self.remove = remove
+
+    def get_remove(self):
+        """Return remove value."""
+        return self.remove
+
+    def _generate_conflicting_reserved_word_list(self, keywords):
+        """Return a set of keywords that may conflict with the specified default reserved words."""
+        conflicting_words = set()
+        for keyword in keywords:
+            conflicting_words.update(set([w for w in self.reserved_words if keyword in w]))
+        if conflicting_words:
+            logging.warning('Specified keywords overlap with reserved words. '
+                            'The following reserved words will be preserved: %s', conflicting_words)
+        return conflicting_words
+
+    @classmethod
+    def _generate_keyword_regex(self, keywords):
+        """Compile and return regex for the specified list of keywords."""
+        return re.compile('({})'.format('|'.join(keywords)), re.IGNORECASE)
+
+    def remove_line(self, line):
+        """Remove the input line."""
+        leading, words, trailing = _split_line(line)
+        for w in words:
+            if w in self.reserved_words:
+                return line
+        if (self.line_regex.search(line) is not None):
+            self.remove = True
+            return 'remove line'
+        else:
+            return line
+
+
 class _sensitive_item_formats(Enum):
     """Enum for recognized sensitive item formats (e.g. type7, md5, text)."""
 

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -28,6 +28,7 @@ password foobar
 password reservedword
 ip address 11.11.11.11 0.0.0.0
 ip address 11.11.197.79 0.0.0.0
+set interfaces interface-name description
 
 """
 
@@ -67,6 +68,7 @@ def test_end_to_end(tmpdir):
         '-w', 'intentionet,sensitive',
         '-r', 'reservedword',
         '-n', '65432,12345',
+        '--remove-line', 'interfaces',
         '--preserve-addresses', '11.11.0.0/16,111.111.111.111',
         '--preserve-prefixes', '192.168.2.0/24',
     ]

--- a/tests/unit/test_anonymize_files.py
+++ b/tests/unit/test_anonymize_files.py
@@ -28,6 +28,7 @@ _INPUT_CONTENTS = """
 ip address 192.168.2.1 255.255.255.255
 my hash is $1$salt$ABCDEFGHIJKLMNOPQRS
 password foobar
+set interfaces interface-name description
 
 """
 _REF_CONTENTS = """
@@ -43,6 +44,10 @@ _SENSITIVE_WORDS = [
     "sensitive",
 ]
 
+_KEYWORDS = [
+    "interfaces",
+]
+
 
 def test_anonymize_files_bad_input_empty(tmpdir):
     """Test anonymize_files with empty input dir."""
@@ -51,7 +56,7 @@ def test_anonymize_files_bad_input_empty(tmpdir):
 
     with pytest.raises(ValueError, match='Input directory is empty'):
         anonymize_files(str(input_dir), str(output_dir), True, True, salt=_SALT,
-                        sensitive_words=_SENSITIVE_WORDS)
+                        sensitive_words=_SENSITIVE_WORDS, keywords=_KEYWORDS)
 
 
 def test_anonymize_files_bad_input_missing(tmpdir):
@@ -117,7 +122,7 @@ def test_anonymize_files_dir(tmpdir):
     output_file = output_dir.join(filename)
 
     anonymize_files(str(input_dir), str(output_dir), True, True, salt=_SALT,
-                    sensitive_words=_SENSITIVE_WORDS)
+                    sensitive_words=_SENSITIVE_WORDS, keywords=_KEYWORDS)
 
     # Make sure output file exists and matches the ref
     assert(os.path.isfile(str(output_file)))
@@ -153,7 +158,7 @@ def test_anonymize_files_dir_nested(tmpdir):
     output_file_2 = output_dir.join("subdir2").join("subsubdir").join(filename)
 
     anonymize_files(str(input_dir), str(output_dir), True, True, salt=_SALT,
-                    sensitive_words=_SENSITIVE_WORDS)
+                    sensitive_words=_SENSITIVE_WORDS, keywords=_KEYWORDS)
 
     # Make sure both output files exists and match the ref
     assert(os.path.isfile(str(output_file_1)))
@@ -172,7 +177,7 @@ def test_anonymize_files_file(tmpdir):
     output_file = tmpdir.mkdir("out").join(filename)
 
     anonymize_files(str(input_file), str(output_file), True, True, salt=_SALT,
-                    sensitive_words=_SENSITIVE_WORDS)
+                    sensitive_words=_SENSITIVE_WORDS, keywords=_KEYWORDS)
 
     # Make sure output file exists and matches the ref
     assert(os.path.isfile(str(output_file)))

--- a/tests/unit/test_anonymize_files.py
+++ b/tests/unit/test_anonymize_files.py
@@ -28,7 +28,6 @@ _INPUT_CONTENTS = """
 ip address 192.168.2.1 255.255.255.255
 my hash is $1$salt$ABCDEFGHIJKLMNOPQRS
 password foobar
-This sentence contains a keyword
 
 """
 _REF_CONTENTS = """
@@ -42,9 +41,6 @@ _SALT = "TESTSALT"
 _SENSITIVE_WORDS = [
     "intentionet",
     "sensitive",
-]
-_KEYWORDS = [
-    "keyword",
 ]
 
 
@@ -86,7 +82,7 @@ def test_anonymize_files_bad_output_file(tmpdir):
     with LogCapture() as log_capture:
         anonymize_files(str(input_file), str(output_file), True, True,
                         salt=_SALT,
-                        sensitive_words=_SENSITIVE_WORDS, keywords=_KEYWORDS)
+                        sensitive_words=_SENSITIVE_WORDS)
         # Confirm the correct message is logged
         log_capture.check_present(
             ('root', 'ERROR', 'Failed to anonymize file {}'.format(str(input_file)))
@@ -121,7 +117,7 @@ def test_anonymize_files_dir(tmpdir):
     output_file = output_dir.join(filename)
 
     anonymize_files(str(input_dir), str(output_dir), True, True, salt=_SALT,
-                    sensitive_words=_SENSITIVE_WORDS, keywords=_KEYWORDS)
+                    sensitive_words=_SENSITIVE_WORDS)
 
     # Make sure output file exists and matches the ref
     assert(os.path.isfile(str(output_file)))
@@ -157,7 +153,7 @@ def test_anonymize_files_dir_nested(tmpdir):
     output_file_2 = output_dir.join("subdir2").join("subsubdir").join(filename)
 
     anonymize_files(str(input_dir), str(output_dir), True, True, salt=_SALT,
-                    sensitive_words=_SENSITIVE_WORDS, keywords=_KEYWORDS)
+                    sensitive_words=_SENSITIVE_WORDS)
 
     # Make sure both output files exists and match the ref
     assert(os.path.isfile(str(output_file_1)))
@@ -176,7 +172,7 @@ def test_anonymize_files_file(tmpdir):
     output_file = tmpdir.mkdir("out").join(filename)
 
     anonymize_files(str(input_file), str(output_file), True, True, salt=_SALT,
-                    sensitive_words=_SENSITIVE_WORDS, keywords=_KEYWORDS)
+                    sensitive_words=_SENSITIVE_WORDS)
 
     # Make sure output file exists and matches the ref
     assert(os.path.isfile(str(output_file)))
@@ -199,7 +195,7 @@ def test_anonymize_file_with_line_remover(tmpdir):
 
     with patch('netconan.sensitive_item_removal.LineRemover') as mock:
         line_remover = mock.return_value
-        line_remover.get_remove.return_value = True
+        line_remover.remove_line.return_value = ''
 
     anonymize_file(str(input_file), str(output_file), None,
                    None, None, None, None, None, False, line_remover)
@@ -218,7 +214,6 @@ def test_anonymize_file_without_line_remover(tmpdir):
     with patch('netconan.sensitive_item_removal.LineRemover') as mock:
         line_remover = mock.return_value
         line_remover.remove_line.return_value = 'Regular sentence'
-        line_remover.get_remove.return_value = False
 
     anonymize_file(str(input_file), str(output_file), None,
                    None, None, None, None, None, False, line_remover)

--- a/tests/unit/test_parse_args.py
+++ b/tests/unit/test_parse_args.py
@@ -30,7 +30,7 @@ def test_defaults():
     assert args.salt is None
     assert not args.undo
     assert args.sensitive_words is None
-    assert args.keyword_remover is None
+    assert args.remove_lines is None
 
 
 def test_no_config_file():
@@ -45,7 +45,7 @@ def test_no_config_file():
         "--salt=salty",
         "--undo",
         "--sensitive-words=secret,password",
-        "--keyword-remover=BGP neighbors,interface decriptions",
+        "--remove-lines=BGP neighbors,interface decriptions",
     ])
 
     assert "in" == args.input
@@ -57,7 +57,7 @@ def test_no_config_file():
     assert "salty" == args.salt
     assert args.undo
     assert "secret,password" == args.sensitive_words
-    assert "BGP neighbors,interface decriptions" == args.keyword_remover
+    assert "BGP neighbors,interface decriptions" == args.remove_lines
 
 
 def test_config_file(tmpdir):
@@ -79,7 +79,7 @@ def test_config_file(tmpdir):
     assert args.salt is None
     assert not args.undo
     assert args.sensitive_words is None
-    assert args.keyword_remover is None
+    assert args.remove_lines is None
 
 
 def test_config_file_and_override(tmpdir):

--- a/tests/unit/test_parse_args.py
+++ b/tests/unit/test_parse_args.py
@@ -30,6 +30,7 @@ def test_defaults():
     assert args.salt is None
     assert not args.undo
     assert args.sensitive_words is None
+    assert args.keyword_remover is None
 
 
 def test_no_config_file():
@@ -44,6 +45,7 @@ def test_no_config_file():
         "--salt=salty",
         "--undo",
         "--sensitive-words=secret,password",
+        "--keyword-remover=BGP neighbors,interface decriptions",
     ])
 
     assert "in" == args.input
@@ -55,6 +57,7 @@ def test_no_config_file():
     assert "salty" == args.salt
     assert args.undo
     assert "secret,password" == args.sensitive_words
+    assert "BGP neighbors,interface decriptions" == args.keyword_remover
 
 
 def test_config_file(tmpdir):
@@ -76,6 +79,7 @@ def test_config_file(tmpdir):
     assert args.salt is None
     assert not args.undo
     assert args.sensitive_words is None
+    assert args.keyword_remover is None
 
 
 def test_config_file_and_override(tmpdir):

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -308,37 +308,34 @@ def test_generate_keyword_regex_return_None(line, keywords, expected):
 
 def test_remove_line():
     """Test if the line is removed."""
-    line = "This is a sentence with a keyword"
-    keywords = ['keyword']
+    line = "set interfaces interface-name description sensitive"
+    keywords = ['interface-name']
     reserved_word = 'reserved'
     remover = LineRemover(keywords, [reserved_word])
     result = remover.remove_line(line)
 
-    assert(result == 'remove line')
-    assert(remover.remove is True)
+    assert(result == '')
 
 
 def test_remove_line_with_no_keywords():
     """Test if the line is not removed."""
-    line = "This is a neighbor"
-    keywords = ['keyword']
+    line = "ip address 192.168.2.1 255.255.255.255"
+    keywords = ['neighbor']
     remover = LineRemover(keywords)
     result = remover.remove_line(line)
 
     assert(result == line)
-    assert(remover.remove is False)
 
 
 def test_remove_line_with_reseved_words():
     """Test if the line removed when there are reserved words."""
-    line = "This is a BGP neighbor"
-    keywords = ['neighbor']
-    reserved_word = 'BGP'
+    line = "set interfaces interface-name description sensitive"
+    keywords = ['interface-name']
+    reserved_word = 'description'
     remover = LineRemover(keywords, [reserved_word])
     result = remover.remove_line(line)
 
     assert(result == line)
-    assert(remover.remove is False)
 
 
 @pytest.mark.parametrize('val', unique_passwords)

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -264,22 +264,6 @@ def test_anonymize_sensitive_words_preserve_reserved_word():
     assert(reserved_word in anon_line.split())
 
 
-def test_generate_conflicting_reserved_word_list():
-    """Test if the set of conflicting reserved words is formed correctly."""
-    reserved_word = 'reserved'
-    keywords = ['reserved', 'keyword1', 'keyword2']
-    remover = LineRemover(keywords, [reserved_word])
-    result = remover._generate_conflicting_reserved_word_list(keywords)
-
-    # Confirm the reserved word is in the set
-    assert(reserved_word in result)
-
-    keywords = ['keyword', 'keyword1', 'keyword2']
-    result = remover._generate_conflicting_reserved_word_list(keywords)
-    # Confirm the reserved word is not in the set
-    assert(reserved_word not in result)
-
-
 @pytest.mark.parametrize("line, keywords, expected", [
         ('other other keyword', ['keyword'], ('keyword',)),
         ('other keyword other', ['keyword'], ('keyword',)),
@@ -310,8 +294,7 @@ def test_remove_line():
     """Test if the line is removed."""
     line = "set interfaces interface-name description sensitive"
     keywords = ['interface-name']
-    reserved_word = 'reserved'
-    remover = LineRemover(keywords, [reserved_word])
+    remover = LineRemover(keywords)
     result = remover.remove_line(line)
 
     assert(result == '')
@@ -322,17 +305,6 @@ def test_remove_line_with_no_keywords():
     line = "ip address 192.168.2.1 255.255.255.255"
     keywords = ['neighbor']
     remover = LineRemover(keywords)
-    result = remover.remove_line(line)
-
-    assert(result == line)
-
-
-def test_remove_line_with_reseved_words():
-    """Test if the line removed when there are reserved words."""
-    line = "set interfaces interface-name description sensitive"
-    keywords = ['interface-name']
-    reserved_word = 'description'
-    remover = LineRemover(keywords, [reserved_word])
     result = remover.remove_line(line)
 
     assert(result == line)

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -17,7 +17,7 @@ from netconan.sensitive_item_removal import (
     _anonymize_value, _check_sensitive_item_format, _extract_enclosing_text,
     _LINE_SCRUBBED_MESSAGE, _sensitive_item_formats,
     generate_default_sensitive_item_regexes, replace_matching_item,
-    SensitiveWordAnonymizer)
+    SensitiveWordAnonymizer, LineRemover)
 import pytest
 
 # Tuple format is config_line, sensitive_text (should not be in output line)
@@ -262,6 +262,83 @@ def test_anonymize_sensitive_words_preserve_reserved_word():
 
     # Confirm the reserved word was not replaced
     assert(reserved_word in anon_line.split())
+
+
+def test_generate_conflicting_reserved_word_list():
+    """Test if the set of conflicting reserved words is formed correctly."""
+    reserved_word = 'reserved'
+    keywords = ['reserved', 'keyword1', 'keyword2']
+    remover = LineRemover(keywords, [reserved_word])
+    result = remover._generate_conflicting_reserved_word_list(keywords)
+
+    # Confirm the reserved word is in the set
+    assert(reserved_word in result)
+
+    keywords = ['keyword', 'keyword1', 'keyword2']
+    result = remover._generate_conflicting_reserved_word_list(keywords)
+    # Confirm the reserved word is not in the set
+    assert(reserved_word not in result)
+
+
+@pytest.mark.parametrize("line, keywords, expected", [
+        ('other other keyword', ['keyword'], ('keyword',)),
+        ('other keyword other', ['keyword'], ('keyword',)),
+        ('keyword other other', ['keyword'], ('keyword',)),
+        ('other    keyword other', ['keyword'], ('keyword',)),
+])
+def test_generate_keyword_regex(line, keywords, expected):
+    """Test if the line matches with the keywords."""
+    line_remover = LineRemover(keywords)
+    result = line_remover._generate_keyword_regex(keywords)
+
+    assert(result.search(line).groups() == expected)
+
+
+@pytest.mark.parametrize("line, keywords, expected", [
+        ('other other other', ['keyword'], None),
+        ('\n\n', ['keyword'], None),
+])
+def test_generate_keyword_regex_return_None(line, keywords, expected):
+    """Test if the method returns None when the line has no keywords."""
+    line_remover = LineRemover(keywords)
+    result = line_remover._generate_keyword_regex(keywords)
+
+    assert(result.search(line) is expected)
+
+
+def test_remove_line():
+    """Test if the line is removed."""
+    line = "This is a sentence with a keyword"
+    keywords = ['keyword']
+    reserved_word = 'reserved'
+    remover = LineRemover(keywords, [reserved_word])
+    result = remover.remove_line(line)
+
+    assert(result == 'remove line')
+    assert(remover.remove is True)
+
+
+def test_remove_line_with_no_keywords():
+    """Test if the line is not removed."""
+    line = "This is a neighbor"
+    keywords = ['keyword']
+    remover = LineRemover(keywords)
+    result = remover.remove_line(line)
+
+    assert(result == line)
+    assert(remover.remove is False)
+
+
+def test_remove_line_with_reseved_words():
+    """Test if the line removed when there are reserved words."""
+    line = "This is a BGP neighbor"
+    keywords = ['neighbor']
+    reserved_word = 'BGP'
+    remover = LineRemover(keywords, [reserved_word])
+    result = remover.remove_line(line)
+
+    assert(result == line)
+    assert(remover.remove is False)
 
 
 @pytest.mark.parametrize('val', unique_passwords)


### PR DESCRIPTION
Implementing this by using a list of keywords given by the user, separated by commas, and removing any line that contains any of these words. The removal is preserved if the line contains any of the words defined in default_reserved_words.py file.

Here is an example:

Running the following command:

`netconan -i cisco.cfg -o result.cfg -k neighbor,keyword`

this warning will appear: 

> WARNING Specified keywords overlap with reserved words. The following reserved words will be preserved: {'neighbor-down', 'neighbor-advertisement', 'log-neighbor-warnings', 'auto-shutdown-new-neighbors', 'log-neighbor-changes', 'neighbor-filter', 'no-neighbor-learn', 'neighbor-group', 'neighbor-solicit', 'neighbor', 'remote-neighbors', 'neighbor-discovery', 'no-neighbor-down-notification'}

The cisco.cfg file is:

![initial_file](https://user-images.githubusercontent.com/44115604/81600740-c3771d00-93d2-11ea-9543-04d2a7680098.PNG)

And the result.cfg file will be:

![result](https://user-images.githubusercontent.com/44115604/81600821-e4d80900-93d2-11ea-8a5d-559a5c9117e5.PNG)

Could you give me some feedback about my work so far? @dhalperi 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/137)
<!-- Reviewable:end -->
