### PR TITLE
#107 Support quoted sensitive phrases with spaces in them

### DIFF
--- a/netconan/default_pwd_regexes.py
+++ b/netconan/default_pwd_regexes.py
@@ -45,24 +45,24 @@
 #  2. sensitive item regex-match-index
 #       note that if this is None, any matching config line will be removed
 default_pwd_line_regexes = [
-    [(r'(?P<prefix>(password|passwd)( level \d+)?( \d+)? )([\"].+[\"]|[\"].+|\S+)', 5)],
+    [(r'(?P<prefix>(password|passwd)( level \d+)?( \d+)? )([\"][^\"]+[\"]|[\"].+|\S+)', 5)],
     [(r'(?P<prefix>username( \S+)+ (password|secret)( \d| sha512)? )(\S+)', 5)],
-    [(r'(?P<prefix>(enable )?secret( \d)? )([\"].+[\"]|[\"].+|\S+)', 4)],
+    [(r'(?P<prefix>(enable )?secret( \d)? )([\"][^\"]+[\"]|[\"].+|\S+)', 4)],
     [(r'(?P<prefix>ip ftp password( \d)? )(\S+)', 3)],
-    [(r'(?P<prefix>ip ospf authentication-key( \d)? )([\"].+[\"]|[\"].+|\S+)', 3)],
+    [(r'(?P<prefix>ip ospf authentication-key( \d)? )([\"][^\"]+[\"]|[\"].+|\S+)', 3)],
     [(r'(?P<prefix>isis password )(\S+)(?=( level-\d)?)', 2)],
     [(r'(?P<prefix>(domain-password|area-password) )(\S+)', 3)],
-    [(r'(?P<prefix>ip ospf message-digest-key \d+ md5( \d)? )([\"].+[\"]|[\"].+|\S+)', 3)],
+    [(r'(?P<prefix>ip ospf message-digest-key \d+ md5( \d)? )([\"][^\"]+[\"]|[\"].+|\S+)', 3)],
     [(r'(?P<prefix>standby( \d*)? authentication( text| md5 key-string( \d)?)? )(\S+)', 5)],
     [(r'(?P<prefix>l2tp tunnel( \S+)? password( \d)? )(\S+)', 4)],
     [(r'(?P<prefix>digest secret( \d)? )(\S+)', 3)],
     [(r'(?P<prefix>ppp .* hostname )(\S+)', 2)],
     [(r'(?P<prefix>ppp .* password( \d)? )(\S+)', 3)],
     [(r'(?P<prefix>(ikev2 )?(local|remote)-authentication pre-shared-key )(\S+)', 4)],
-    [(r'(?P<prefix>(\S )*pre-shared-key( remote| local)?( hex| hexadecimal| ascii-text| \d)? )([\"].+[\"]|[\"].+|\S+)', 5)],
+    [(r'(?P<prefix>(\S )*pre-shared-key( remote| local)?( hex| hexadecimal| ascii-text| \d)? )([\"][^\"]+[\"]|[\"].+|\S+)', 5)],
     [(r'(?P<prefix>(tacacs|radius)-server (\S+ )*key( \d)? )(\S+)', 5)],
-    [(r'(?P<prefix>key( \d| hexadecimal)? )([\"].+[\"]|[\"].+|\S+)', 3)],
-    [(r'(?P<prefix>ntp authentication-key \d+ md5 )([\"].+[\"]|[\"].+|\S+)', 2)],
+    [(r'(?P<prefix>key( \d| hexadecimal)? )([\"][^\"]+[\"]|[\"].+|\S+)', 3)],
+    [(r'(?P<prefix>ntp authentication-key \d+ md5 )([\"][^\"]+[\"]|[\"].+|\S+)', 2)],
     [(r'(?P<prefix>syscon( password| address \S+) )(\S+)', 3)],
     [(r'(?P<prefix>snmp-server user( \S+)+ (auth (md5|sha)) )(\S+)', 5),
      (r'(?P<prefix>snmp-server user( \S+)+ priv( 3des| aes( \d+)?| des)? )(\S+)', 5)],
@@ -70,7 +70,7 @@ default_pwd_line_regexes = [
     [(r'(?P<prefix>set session-key (in|out)bound ah \d+ )(\S+)', 3)],
     [(r'(?P<prefix>set session-key (in|out)bound esp \d+ cipher? )(\S+)', 3),
      (r'(?P<prefix>set session-key (in|out)bound esp \d+(( cipher \S+)? authenticator) )(\S+)', 5)],
-    [(r'(?P<prefix>(hello-)?authentication-key )([^;]+)', 3)],
+    [(r'(?P<prefix>(hello-)?authentication-key )([\"][^\"]+[\"]|[^;]+)', 3)],
     # TODO(https://github.com/intentionet/netconan/issues/3):
     # Follow-up on these.  They were just copied from RANCID so currently:
     #   They are untested in general and need cases added for unit tests
@@ -111,5 +111,5 @@ default_com_line_regexes = [
     # See if we need to make the snmp keyword optional for Juniper
     # Also, this needs to be tested against config lines generated on a JUNOS router
     #     (to make sure the regex handles different syntaxes allowed in the line)
-    [(r'(?P<prefix>(\S* )*snmp( \S+)* (community|trap-group) )([\"].+[\"]|[\"].+|[^ ;]+)', 5)]
+    [(r'(?P<prefix>(\S* )*snmp( \S+)* (community|trap-group) )([\"][^\"]+[\"]|[\"].+|[^ ;]+)', 5)]
 ]

--- a/netconan/default_pwd_regexes.py
+++ b/netconan/default_pwd_regexes.py
@@ -45,24 +45,27 @@
 #  2. sensitive item regex-match-index
 #       note that if this is None, any matching config line will be removed
 default_pwd_line_regexes = [
-    [(r'(?P<prefix>(password|passwd)( level \d+)?( \d+)? )([\"][^\"]+[\"]|[\"].+|\S+)', 5)],
+    # Since quotation marks placed at the the end of a config line are removed
+    # before anonymizing, the |[\"][^\"]+| is used to match passwords
+    # that are enclosed in quotation marks and, also, placed at the end of a config line.
+    [(r'(?P<prefix>(password|passwd)( level \d+)?( \d+)? )([\"][^\"]+[\"]|[\"][^\"]+|\S+)', 5)],
     [(r'(?P<prefix>username( \S+)+ (password|secret)( \d| sha512)? )(\S+)', 5)],
-    [(r'(?P<prefix>(enable )?secret( \d)? )([\"][^\"]+[\"]|[\"].+|\S+)', 4)],
+    [(r'(?P<prefix>(enable )?secret( \d)? )([\"][^\"]+[\"]|[\"][^\"]+|\S+)', 4)],
     [(r'(?P<prefix>ip ftp password( \d)? )(\S+)', 3)],
     [(r'(?P<prefix>ip ospf authentication-key( \d)? )([\"][^\"]+[\"]|[\"].+|\S+)', 3)],
     [(r'(?P<prefix>isis password )(\S+)(?=( level-\d)?)', 2)],
     [(r'(?P<prefix>(domain-password|area-password) )(\S+)', 3)],
-    [(r'(?P<prefix>ip ospf message-digest-key \d+ md5( \d)? )([\"][^\"]+[\"]|[\"].+|\S+)', 3)],
+    [(r'(?P<prefix>ip ospf message-digest-key \d+ md5( \d)? )([\"][^\"]+[\"]|[\"][^\"]+|\S+)', 3)],
     [(r'(?P<prefix>standby( \d*)? authentication( text| md5 key-string( \d)?)? )(\S+)', 5)],
     [(r'(?P<prefix>l2tp tunnel( \S+)? password( \d)? )(\S+)', 4)],
     [(r'(?P<prefix>digest secret( \d)? )(\S+)', 3)],
     [(r'(?P<prefix>ppp .* hostname )(\S+)', 2)],
     [(r'(?P<prefix>ppp .* password( \d)? )(\S+)', 3)],
     [(r'(?P<prefix>(ikev2 )?(local|remote)-authentication pre-shared-key )(\S+)', 4)],
-    [(r'(?P<prefix>(\S )*pre-shared-key( remote| local)?( hex| hexadecimal| ascii-text| \d)? )([\"][^\"]+[\"]|[\"].+|\S+)', 5)],
+    [(r'(?P<prefix>(\S )*pre-shared-key( remote| local)?( hex| hexadecimal| ascii-text| \d)? )([\"][^\"]+[\"]|[\"][^\"]+|\S+)', 5)],
     [(r'(?P<prefix>(tacacs|radius)-server (\S+ )*key( \d)? )(\S+)', 5)],
-    [(r'(?P<prefix>key( \d| hexadecimal)? )([\"][^\"]+[\"]|[\"].+|\S+)', 3)],
-    [(r'(?P<prefix>ntp authentication-key \d+ md5 )([\"][^\"]+[\"]|[\"].+|\S+)', 2)],
+    [(r'(?P<prefix>key( \d| hexadecimal)? )([\"][^\"]+[\"]|[\"][^\"]+|\S+)', 3)],
+    [(r'(?P<prefix>ntp authentication-key \d+ md5 )([\"][^\"]+[\"]|[\"][^\"]+|\S+)', 2)],
     [(r'(?P<prefix>syscon( password| address \S+) )(\S+)', 3)],
     [(r'(?P<prefix>snmp-server user( \S+)+ (auth (md5|sha)) )(\S+)', 5),
      (r'(?P<prefix>snmp-server user( \S+)+ priv( 3des| aes( \d+)?| des)? )(\S+)', 5)],
@@ -111,5 +114,5 @@ default_com_line_regexes = [
     # See if we need to make the snmp keyword optional for Juniper
     # Also, this needs to be tested against config lines generated on a JUNOS router
     #     (to make sure the regex handles different syntaxes allowed in the line)
-    [(r'(?P<prefix>(\S* )*snmp( \S+)* (community|trap-group) )([\"][^\"]+[\"]|[\"].+|[^ ;]+)', 5)]
+    [(r'(?P<prefix>(\S* )*snmp( \S+)* (community|trap-group) )([\"][^\"]+[\"]|[\"][^\"]+|[^ ;]+)', 5)]
 ]

--- a/netconan/default_pwd_regexes.py
+++ b/netconan/default_pwd_regexes.py
@@ -44,29 +44,25 @@
 #       text matches the `prefix` group is kept in the anonymized line
 #  2. sensitive item regex-match-index
 #       note that if this is None, any matching config line will be removed
-#
-# TODO(https://github.com/intentionet/netconan/issues/107)
-# Some of these regexes need to be updated to support quote enclosed passwords
-# which is allowed for at least some syntax on Juniper devices
 default_pwd_line_regexes = [
-    [(r'(?P<prefix>(password|passwd)( level \d+)?( \d+)? )(\S+)', 5)],
+    [(r'(?P<prefix>(password|passwd)( level \d+)?( \d+)? )([\"].+[\"]|[\"].+|\S+)', 5)],
     [(r'(?P<prefix>username( \S+)+ (password|secret)( \d| sha512)? )(\S+)', 5)],
-    [(r'(?P<prefix>(enable )?secret( \d)? )(\S+)', 4)],
+    [(r'(?P<prefix>(enable )?secret( \d)? )([\"].+[\"]|[\"].+|\S+)', 4)],
     [(r'(?P<prefix>ip ftp password( \d)? )(\S+)', 3)],
-    [(r'(?P<prefix>ip ospf authentication-key( \d)? )(\S+)', 3)],
+    [(r'(?P<prefix>ip ospf authentication-key( \d)? )([\"].+[\"]|[\"].+|\S+)', 3)],
     [(r'(?P<prefix>isis password )(\S+)(?=( level-\d)?)', 2)],
     [(r'(?P<prefix>(domain-password|area-password) )(\S+)', 3)],
-    [(r'(?P<prefix>ip ospf message-digest-key \d+ md5( \d)? )(\S+)', 3)],
+    [(r'(?P<prefix>ip ospf message-digest-key \d+ md5( \d)? )([\"].+[\"]|[\"].+|\S+)', 3)],
     [(r'(?P<prefix>standby( \d*)? authentication( text| md5 key-string( \d)?)? )(\S+)', 5)],
     [(r'(?P<prefix>l2tp tunnel( \S+)? password( \d)? )(\S+)', 4)],
     [(r'(?P<prefix>digest secret( \d)? )(\S+)', 3)],
     [(r'(?P<prefix>ppp .* hostname )(\S+)', 2)],
     [(r'(?P<prefix>ppp .* password( \d)? )(\S+)', 3)],
     [(r'(?P<prefix>(ikev2 )?(local|remote)-authentication pre-shared-key )(\S+)', 4)],
-    [(r'(?P<prefix>(\S )*pre-shared-key( remote| local)?( hex| hexadecimal| ascii-text| \d)? )(\S+)', 5)],
+    [(r'(?P<prefix>(\S )*pre-shared-key( remote| local)?( hex| hexadecimal| ascii-text| \d)? )([\"].+[\"]|[\"].+|\S+)', 5)],
     [(r'(?P<prefix>(tacacs|radius)-server (\S+ )*key( \d)? )(\S+)', 5)],
-    [(r'(?P<prefix>key( \d| hexadecimal)? )(\S+)', 3)],
-    [(r'(?P<prefix>ntp authentication-key \d+ md5 )(\S+)', 2)],
+    [(r'(?P<prefix>key( \d| hexadecimal)? )([\"].+[\"]|[\"].+|\S+)', 3)],
+    [(r'(?P<prefix>ntp authentication-key \d+ md5 )([\"].+[\"]|[\"].+|\S+)', 2)],
     [(r'(?P<prefix>syscon( password| address \S+) )(\S+)', 3)],
     [(r'(?P<prefix>snmp-server user( \S+)+ (auth (md5|sha)) )(\S+)', 5),
      (r'(?P<prefix>snmp-server user( \S+)+ priv( 3des| aes( \d+)?| des)? )(\S+)', 5)],
@@ -115,5 +111,5 @@ default_com_line_regexes = [
     # See if we need to make the snmp keyword optional for Juniper
     # Also, this needs to be tested against config lines generated on a JUNOS router
     #     (to make sure the regex handles different syntaxes allowed in the line)
-    [(r'(?P<prefix>(\S* )*snmp( \S+)* (community|trap-group) )([^ ;]+)', 5)]
+    [(r'(?P<prefix>(\S* )*snmp( \S+)* (community|trap-group) )([\"].+[\"]|[\"].+|[^ ;]+)', 5)]
 ]

--- a/tests/unit/test_anonymize_files.py
+++ b/tests/unit/test_anonymize_files.py
@@ -26,6 +26,7 @@ _INPUT_CONTENTS = """
 ip address 192.168.2.1 255.255.255.255
 my hash is $1$salt$ABCDEFGHIJKLMNOPQRS
 password foobar
+set license keys key "foo bar"
 
 """
 _REF_CONTENTS = """
@@ -33,6 +34,7 @@ _REF_CONTENTS = """
 ip address 192.168.139.13 255.255.255.255
 my hash is $1$0000$CxUUGIrqPb7GaB5midrQZ.
 password netconanRemoved1
+set license keys key "netconanRemoved2"
 
 """
 _SALT = "TESTSALT"

--- a/tests/unit/test_sensitive_item_removal.py
+++ b/tests/unit/test_sensitive_item_removal.py
@@ -135,8 +135,20 @@ juniper_password_with_spaces_lines = [
     ('edit security ike policy pre-shared-key ascii-text "{}"', 'PaSS worD'),
     ('ip ospf message-digest-key 2 md5 "{}"', 'paSSworD sensitIVE'),
     ('set snmp trap-group "{}"', 'SeCRET TEXT'),
+    ('set interfaces irb unit 5 family inet address 1.2.3.0/24 vrrp-group 5 authentication-key "{}"', 'SentTiVe INfo2'),
     ('set snmp community "{}" authorization read-only', 'Pass WOrd'),
-    ('set interfaces irb unit 5 family inet address 1.2.3.0/24 vrrp-group 5 authentication-key "{}"', 'SentTiVe INfo2')
+    # Cases to make sure that the patterns
+    # only consume and match two double quotes ""
+    # to anonymize
+    ('set system license keys key "{}" and "another quoted value"', 'SOMETHING sensitive'),
+    ('set system tacplus-server 1.2.3.4 secret "{}" and "anotherValue"', 'paSSword5se'),
+    ('set ip ospf authentication-key "{}" and "Quoted value"', 'Pass 5'),
+    ('enable password "{}" and "something else"', 'paSSw ordsensItIVE'),
+    ('authentication-key "{}" and "something else"', 'paSSword 5 sensitIVE'),
+    ('hello-authentication-key "{}" #""', 'PaSS worD'),
+    ('edit security ike policy pre-shared-key ascii-text "{}" more "quotes"', 'PaSS worD'),
+    ('ip ospf message-digest-key 2 md5 "{}" and "quoted"', 'paSSworD sensitIVE'),
+    ('set snmp community "{}" description "qfabric0 switch"', 'Pass WOrd'),
 ]
 
 passwords_with_spaces = [


### PR DESCRIPTION
This pull request is about issue #107 . 
Implementing this change by modifying some regexes in default_pwd_regexes in order to allow passwords that are enclosed in quotes to be anonymized as a single word. This regexes match config lines that are used in juniper devices where quoted phrases are allowed.

Here is an example of the implemenation:

Running the following command

`
netconan -i juniper.cfg -o anonymized.cfg -p
`

with the following content in juniper.cfg

![juniper](https://user-images.githubusercontent.com/44121330/81909714-a8bfc680-95d3-11ea-99c7-4a3f6503d7fc.PNG)

the anonymized.cfg will contain the following 

![anonymized2](https://user-images.githubusercontent.com/44121330/81909793-c42ad180-95d3-11ea-9cdf-1632e0d9f094.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/138)
<!-- Reviewable:end -->
