### PR TITLE
Fix dependency resolution issues

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -5,7 +5,7 @@ if [ -n "$TRAVIS_BUILD_DIR" ]; then
    # Upgrade pip
    pip install -U pip
    # Build and install netconan
-   pip install -e .[dev]
+   pip install -e .[dev,test]
 fi
 
 echo -e "\n  ..... Running flake8 on netconan to check style and docstrings"

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,16 @@ setup(
             'flake8-docstrings<2.0.0',
             'pydocstyle<4.0.0'
         ],
-        # 'test': ['coverage', 'pytz'],
+        # Duplicated test deps here for now, since dependency resolution is
+        # failing for python2.7 in CI
+        'test': [
+            'pytest>=4.2.0,<5.0.0',
+            'pytest-cov<3.0.0',
+            'requests_mock<2.0.0',
+            'testfixtures<7.0.0',
+            # zipp 2.2 does not work w/ Python < 3.6
+            'zipp<2.2',
+        ],
     },
 
     # List pytest requirements for running unit tests

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         # Duplicated test deps here for now, since dependency resolution is
         # failing for python2.7 in CI
         'test': [
-            'pytest>=4.2.0,<5.0.0',
+            'pytest>=4.6.0,<5.0.0',
             'pytest-cov<3.0.0',
             'requests_mock<2.0.0',
             'testfixtures<7.0.0',
@@ -99,7 +99,7 @@ setup(
     setup_requires=['pytest-runner<6.0'],
     # pytest 5+ does not support Python 2
     tests_require=[
-        'pytest>=4.2.0,<5.0.0',
+        'pytest>=4.6.0,<5.0.0',
         'pytest-cov<3.0.0',
         'requests_mock<2.0.0',
         'testfixtures<7.0.0',


### PR DESCRIPTION
CI is having dependency resolution issues w/ `tests_require` in `python2.7` (e.g. [see this build](https://travis-ci.com/github/intentionet/netconan/jobs/348656177)):
* Not installing `python2` compatible version of dependencies (e.g. installing `pyparsing` `3.0.0a1`, which is `python3` only)

---

This PR explicitly enumerates test dependencies in a `test` section in `extras_require` and bumps the required version of `pytest` (required by new `pytest-cov`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/140)
<!-- Reviewable:end -->
