### PR TITLE
netconan: anonymize sensitive words in a case-sensitive way

### DIFF
--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -136,8 +136,9 @@ class SensitiveWordAnonymizer(object):
         self.reserved_words = {w.lower() for w in reserved_words}
         sensitive_words_ = {w.lower() for w in sensitive_words}
 
+        self.salt = salt
         self.sens_regex = self._generate_sensitive_word_regex(sensitive_words_)
-        self.sens_word_replacements = self._generate_sensitive_word_replacements(sensitive_words_, salt)
+        self.sens_word_replacements = {}
         # Figure out which reserved words may clash with sensitive words, so they can be preserved in anonymization
         self.conflicting_words = self._generate_conflicting_reserved_word_list(sensitive_words_)
 
@@ -168,19 +169,21 @@ class SensitiveWordAnonymizer(object):
         """Compile and return regex for the specified list of sensitive words."""
         return re.compile('({})'.format('|'.join(sensitive_words)), re.IGNORECASE)
 
-    @classmethod
-    def _generate_sensitive_word_replacements(cls, sensitive_words, salt):
-        """Compile and return a dict of sensitive word replacements."""
-        # Only using part of the md5 hash result as the anonymized replacement
-        # to cut down on the size of the replacements
-        return {
-            sens_word.lower(): md5((salt + sens_word.lower()).encode()).hexdigest()[:_ANON_SENSITIVE_WORD_LEN]
-            for sens_word in sensitive_words
-        }
+    def _get_or_generate_sensitive_word_replacement(self, sensitive_word):
+        """Return the replacement string for the given sensitive word.
+
+        Generates the replacement if necessary."""
+        replacement = self.sens_word_replacements.get(sensitive_word)
+        if replacement is None:
+            # Only using part of the md5 hash result as the anonymized replacement
+            # to cut down on the size of the replacements
+            replacement = md5((self.salt + sensitive_word).encode()).hexdigest()[:_ANON_SENSITIVE_WORD_LEN]
+            self.sens_word_replacements[sensitive_word] = replacement
+        return replacement
 
     def _lookup_anon_word(self, match):
         """Lookup anonymized word for the given sensitive word regex match."""
-        return self.sens_word_replacements[match.group(0).lower()]
+        return self._get_or_generate_sensitive_word_replacement(match.group(0))
 
 
 class _sensitive_item_formats(Enum):

--- a/netconan/sensitive_item_removal.py
+++ b/netconan/sensitive_item_removal.py
@@ -172,7 +172,8 @@ class SensitiveWordAnonymizer(object):
     def _get_or_generate_sensitive_word_replacement(self, sensitive_word):
         """Return the replacement string for the given sensitive word.
 
-        Generates the replacement if necessary."""
+        Generates the replacement if necessary.
+        """
         replacement = self.sens_word_replacements.get(sensitive_word)
         if replacement is None:
             # Only using part of the md5 hash result as the anonymized replacement

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -36,7 +36,7 @@ ip address 11.11.197.79 0.0.0.0
 """
 
 REF_CONTENTS = """
-# 1cbbc2's fd8607 test file
+# a4daba's fd8607 test file
 ip address 192.168.2.13 255.255.255.255
 ip address 111.111.111.111
 ip address 5.86.28.249 0.0.0.0
@@ -46,7 +46,7 @@ password netconanRemoved1
 password reservedword
 ip address 11.11.11.11 0.0.0.0
 ip address 11.11.197.79 0.0.0.0
-# fd8607 word e77b71 here
+# 3b836f word 10b348 here
 
 """
 

--- a/tests/unit/test_anonymize_files.py
+++ b/tests/unit/test_anonymize_files.py
@@ -29,7 +29,7 @@ password foobar
 
 """
 _REF_CONTENTS = """
-# 1cbbc2's fd8607 test file
+# a4daba's fd8607 test file
 ip address 192.168.139.13 255.255.255.255
 my hash is $1$0000$CxUUGIrqPb7GaB5midrQZ.
 password netconanRemoved1


### PR DESCRIPTION
We made sensitive words case-insensitive so that users don't have to know
in advance all possible cases in which they appear. E.g., Intentionet, intentionet.

However, despite matching any case, we should anonymize each case separately. This will
leak less information if for some reason one occurrence is guessable, otherws will not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/148)
<!-- Reviewable:end -->
