### PR TITLE
netconan: preserve host bits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,13 +70,15 @@ Netconan attempts to *preserve useful structure*. For example,
 
 * Netconan preserves prefixes when anonymizing IPv4 and IPv6 addresses: IP addresses with a common prefix before anonymization will share the same prefix length after anonymization. For more information, see J. Xu et al., *On the Design and Performance of Prefix-Preserving IP Traffic Trace Anonymization*, ACM SIGCOMM Workshop on Internet Measurement, 2001 [`link <https://smartech.gatech.edu/bitstream/handle/1853/6573/GIT-CC-01-22.pdf>`_].
 
-* IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overriden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
+* IPv4 classes and private-use prefixes (see `IANA IPv4 assignments <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_) are preserved by default, but can be overridden (with ``--preserve-prefixes`` e.g. ``--preserve-prefixes 12.0.0.0/8`` will preserve a leading octet ``12`` of IP addresses encountered but anonymize octets after the ``12``).
+
+* By default, the last ``8`` bits of each IP address are preserved. This prevents IP anonymization from breaking important network structure such as point-to-point IPv4 /30 links or NAT pools. This can be overridden to a new number ``B`` using ``--preserve-host-bits B``, and it can be disabled entirely using ``--preserve-host-bits 0``.
 
 * Specific addresses can optionally be preserved, e.g.
 
-  - ``--preserve-addresses`` skips anonymizing the specified network or address e.g. ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` network and skip anonymizing ``13.12.11.10``.
+  - ``--preserve-addresses`` skips anonymizing the specified network or address. For example, ``--preserve-addresses 12.0.0.0/8,13.12.11.10`` will skip anonymization for any address in the ``12.0.0.0/8`` network and skip anonymizing ``13.12.11.10``.
 
-  - ``--preserve-private-addresses`` skips anonymizing addresses that fall under private-use blocks.
+  - ``--preserve-private-addresses`` skips anonymizing all addresses that fall under private-use blocks.
 
 * AS number blocks are preserved (i.e. an anonymized public AS number will still be in the public AS number range after anonymization).
 
@@ -99,6 +101,9 @@ For more information about less commonly-used features, see the Netconan help (`
                     [-l {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-n AS_NUMBERS] -o
                     OUTPUT [-p] [-r RESERVED_WORDS] [-s SALT] [-u]
                     [-w SENSITIVE_WORDS] [--preserve-prefixes PRESERVE_PREFIXES]
+                    [--preserve-addresses PRESERVE_ADDRESSES]
+                    [--preserve-private-addresses]
+                    [--preserve-host-bits PRESERVE_HOST_BITS]
 
     Args that can start with '--' can also be set in a config file (specified via
     -c). If an arg is specified in more than one place, then command line values
@@ -151,3 +156,8 @@ For more information about less commonly-used features, see the Netconan help (`
                             --preserve-addresses instead. To preserve just
                             prefixes and anonymize host bits, use --preserve-
                             prefixes
+      --preserve-host-bits PRESERVE_HOST_BITS
+                            Preserve the trailing bits of IP addresses, aka the
+                            host bits of a network. Set this value large enough to
+                            represent the largest interface network (e.g., 8 for a
+                            /24 or 12 for a /20) or NAT pool.

--- a/netconan/anonymize_files.py
+++ b/netconan/anonymize_files.py
@@ -34,7 +34,8 @@ _CHAR_CHOICES = string.ascii_letters + string.digits
 def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
                     salt=None, dumpfile=None, sensitive_words=None,
                     undo_ip_anon=False, as_numbers=None, reserved_words=None,
-                    preserve_prefixes=None, preserve_networks=None):
+                    preserve_prefixes=None, preserve_networks=None,
+                    preserve_suffix_v4=None, preserve_suffix_v6=None):
     """Anonymize each file in input and save to output."""
     anonymizer4 = None
     anonymizer6 = None
@@ -56,8 +57,8 @@ def anonymize_files(input_path, output_path, anon_pwd, anon_ip,
     if sensitive_words is not None:
         anonymizer_sensitive_word = SensitiveWordAnonymizer(sensitive_words, salt)
     if anon_ip or undo_ip_anon:
-        anonymizer4 = IpAnonymizer(salt, preserve_prefixes, preserve_networks)
-        anonymizer6 = IpV6Anonymizer(salt)
+        anonymizer4 = IpAnonymizer(salt, preserve_prefixes, preserve_networks, preserve_suffix=preserve_suffix_v4)
+        anonymizer6 = IpV6Anonymizer(salt, preserve_suffix=preserve_suffix_v6)
     if as_numbers is not None:
         anonymizer_as_num = AsNumberAnonymizer(as_numbers, salt)
 

--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -75,16 +75,21 @@ def _ensure_unicode(str):
 
 @add_metaclass(ABCMeta)
 class _BaseIpAnonymizer(object):
-    def __init__(self, salt, length, salter=_generate_bit_from_hash):
+    def __init__(self, salt, length, salter=_generate_bit_from_hash, preserve_suffix=None):
         self.salt = salt
         self.cache = bidict({'': ''})
         self.length = length
         self.fmt = '{{:0{length}b}}'.format(length=length)
         self.salter = salter
+        self.preserve_suffix = 0 if preserve_suffix is None else preserve_suffix
 
     def anonymize(self, ip_int):
         bits = self.fmt.format(ip_int)
-        anon_bits = self._anonymize_bits(bits)
+        if self.preserve_suffix == 0:
+            anon_bits = self._anonymize_bits(bits)
+        else:
+            to_anon, to_preserve = bits[:-self.preserve_suffix], bits[-self.preserve_suffix:]
+            anon_bits = self._anonymize_bits(to_anon) + to_preserve
         return int(anon_bits, 2)
 
     def _anonymize_bits(self, bits):

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -14,6 +14,9 @@
 #   limitations under the License.
 
 from __future__ import absolute_import
+
+import argparse
+
 import configargparse
 import logging
 import sys
@@ -21,6 +24,15 @@ import sys
 from .ip_anonymization import IpAnonymizer
 from .anonymize_files import anonymize_files
 from . import __version__
+
+
+def host_bits(x):
+    """Argparse type function for --preserve-host-bits."""
+    # the name of this function is used for error message, apparently.
+    val = int(x)
+    if val < 0 or val > 32:
+        raise argparse.ArgumentError('valid values are [0, 32]')
+    return val
 
 
 def _parse_args(argv):
@@ -74,7 +86,7 @@ def _parse_args(argv):
                         action='store_true', default=False,
                         help='Preserve private-use IP addresses. Prefixes and host bits within the private-use IP networks are preserved. To preserve specific addresses or networks, use --preserve-addresses instead. To preserve just prefixes and anonymize host bits, use --preserve-prefixes')
     parser.add_argument('--preserve-host-bits',
-                        type=int, default=8,
+                        type=host_bits, default=8,
                         help='Preserve the trailing bits of IP addresses, aka the host bits of a network. Set this value large enough to represent the largest interface network (e.g., 8 for a /24 or 12 for a /20) or NAT pool.')
     return parser.parse_args(argv)
 

--- a/netconan/netconan.py
+++ b/netconan/netconan.py
@@ -73,6 +73,9 @@ def _parse_args(argv):
     parser.add_argument('--preserve-private-addresses',
                         action='store_true', default=False,
                         help='Preserve private-use IP addresses. Prefixes and host bits within the private-use IP networks are preserved. To preserve specific addresses or networks, use --preserve-addresses instead. To preserve just prefixes and anonymize host bits, use --preserve-prefixes')
+    parser.add_argument('--preserve-host-bits',
+                        type=int, default=8,
+                        help='Preserve the trailing bits of IP addresses, aka the host bits of a network. Set this value large enough to represent the largest interface network (e.g., 8 for a /24 or 12 for a /20) or NAT pool.')
     return parser.parse_args(argv)
 
 
@@ -142,7 +145,9 @@ def main(argv=sys.argv[1:]):
         anonymize_files(args.input, args.output, args.anonymize_passwords,
                         args.anonymize_ips, args.salt, args.dump_ip_map,
                         sensitive_words, args.undo, as_numbers, reserved_words,
-                        preserve_prefixes, preserve_addresses)
+                        preserve_prefixes, preserve_addresses,
+                        preserve_suffix_v4=args.preserve_host_bits,
+                        preserve_suffix_v6=args.preserve_host_bits)
 
 
 if __name__ == '__main__':

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -37,9 +37,9 @@ ip address 11.11.197.79 0.0.0.0
 
 REF_CONTENTS = """
 # a4daba's fd8607 test file
-ip address 192.168.2.13 255.255.255.255
+ip address 192.168.2.1 255.255.255.255
 ip address 111.111.111.111
-ip address 5.86.28.249 0.0.0.0
+ip address 5.86.3.4 0.0.0.0
 my hash is $1$0000$CxUUGIrqPb7GaB5midrQZ.
 AS num 8625 and 64818 should be changed
 password netconanRemoved1
@@ -74,6 +74,7 @@ def test_end_to_end(tmpdir):
         '-n', '65432,12345',
         '--preserve-addresses', '11.11.0.0/16,111.111.111.111',
         '--preserve-prefixes', '192.168.2.0/24',
+        '--preserve-host-bits', '17',
     ]
     main(args)
 


### PR DESCRIPTION
IP Anonymization breaks important structure when it anonymizes IP address
inside of interface addresses or NAT pools. For example, a link 10.0.0.1/30
and 10.0.0.2/30 will be broken 3/4 of the time because one of the IPs may
get anonymized to 10.0.0.0 (the network address) or 10.0.0.3 (the broadcast
address).

Similarly, a NAT pool like 10.0.0.0 to 10.0.0.5 might get anonymized to
10.0.0.7 to 10.0.0.1, which is invalid (backwards) and would have a different
size if we flipped the end points. This can be especially problematic for
Static NAT if we map both start and end IPs: 1.1.1.1-1.1.1.5 and 2.2.2.1-2.2.2.5.
There is no guarantee that after anonymization, the pools will be the same size!

To fix this, users can use the --preserve-host-bits B flag to prevent
netconan from anonymizing the last B bits of an IP Address (v4 or v6). That means
that while the prefix of each IP address is anonmyized, the last B bits are not.
As long as B is greater than 2, a /30 will never be disconnected by anonymization.

We choose B=8 by default as this captures most interface addresses (/24) and NAT
pool sizes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/150)
<!-- Reviewable:end -->
