### PR TITLE
Better IP address detection

### DIFF
--- a/netconan/ip_anonymization.py
+++ b/netconan/ip_anonymization.py
@@ -27,8 +27,8 @@ from six import add_metaclass, iteritems, text_type, u
 _IPv4_OCTET_PATTERN = r"(25[0-5]|(2[0-4]|1?[0-9])?[0-9])"
 
 # Match address starting at beginning of line or surrounded by these, appropriate enclosing chars
-_IPv4_ENCLOSING = r"[^\w.]"  # Match anything but "word" chars or `.`
-_IPv6_ENCLOSING = r"[^\w:]"  # Match anything but "word" chars or `:`
+_IPv4_ENCLOSING = r"[^a-zA-Z0-9.]"  # Match anything but "word" chars (minus underscore) or `.`
+_IPv6_ENCLOSING = r"[^a-zA-Z0-9:]"  # Match anything but "word" chars (minus underscore) or `:`
 
 # Deliberately allowing leading zeros and will remove them later
 IPv4_PATTERN = re.compile(

--- a/tests/unit/test_ip_anonymization.py
+++ b/tests/unit/test_ip_anonymization.py
@@ -153,7 +153,7 @@ def test_v4_anonymize_line(anonymizer_v4, line, ip_addrs):
     anonymize_line_general(anonymizer_v4, line, ip_addrs)
 
 
-@pytest.mark.parametrize("enclosing", ":;[]$~!@#$%^&*()-+=[]|<>?")
+@pytest.mark.parametrize("enclosing", "_:;[]$~!@#$%^&*()-+=[]|<>?")
 def test_v4_anonymize_enclosed_addr(anonymizer_v4, enclosing):
     """Test IPv4 address removal from config lines with different enclosing characters."""
     ip_addr = "1.2.3.4"


### PR DESCRIPTION
Expand allowed enclosing characters to include `_`

This allows anonymizing things like `object_name_10.10.10.10`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/159)
<!-- Reviewable:end -->
