### PR TITLE
Setup: only require `ipaddress` for older python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ setup(
         "bidict<1.0.0",
         # Only use enum34 for Python older than 3.4
         'enum34<2.0.0; python_version < "3.4"',
-        "ipaddress<2.0.0",
+        # ipaddress is in the Python standard library in 3.3+
+        'ipaddress<2.0.0; python_version < "3.3"',
         "passlib<2.0.0",
         "six<2.0.0",
     ],


### PR DESCRIPTION
`ipaddress` is part of the Python standard library since 3.3, so only require it for older versions of Python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intentionet/netconan/171)
<!-- Reviewable:end -->
