### PR TITLE
netconan: permit configargparse major version 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        "configargparse<1.0.0",
+        "configargparse<2.0.0",
         "bidict<1.0.0",
         "passlib<2.0.0",
     ],


### PR DESCRIPTION
They bumped to 1.0.0 immediately after the version
we used, without breaking anything.

commit-id:106c0995

---

**Stack**:
- #185
- #184 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*